### PR TITLE
Add QP to quests in API response

### DIFF
--- a/apps/api/src/lib/profiles/get-profile.ts
+++ b/apps/api/src/lib/profiles/get-profile.ts
@@ -149,7 +149,7 @@ async function getProfile(db: Database, condition: SQL) {
       id: profileQuest.id,
       name: quest?.name || "Unknown",
       state: profileQuest.state,
-      type: quest?.type || -1,
+      type: quest?.type ?? -1,
       points: quest?.points ?? 0,
     };
   });

--- a/apps/api/src/lib/profiles/get-profile.ts
+++ b/apps/api/src/lib/profiles/get-profile.ts
@@ -150,6 +150,7 @@ async function getProfile(db: Database, condition: SQL) {
       name: quest?.name || "Unknown",
       state: profileQuest.state,
       type: quest?.type || -1,
+      points: quest?.points ?? 0,
     };
   });
 


### PR DESCRIPTION
It would be useful for apps consuming the RuneProfile API to include quest points in the `quests` response, this would save clients from having to maintain a separate mapping of quest:QP to calculate the total quest points a player has.