### PR TITLE
Add a toggle to hide completed combat achievement bosses 

### DIFF
--- a/apps/web/src/features/profile/components/combat-achievements-panel.tsx
+++ b/apps/web/src/features/profile/components/combat-achievements-panel.tsx
@@ -49,6 +49,8 @@ type CombatAchievementsPanelProps = {
   onTypeFilterChange: (value: string) => void;
   completionFilter: CompletionFilter;
   onCompletionFilterChange: (value: CompletionFilter) => void;
+  hideCompletedBosses: boolean;
+  onHideCompletedBossesChange: (value: boolean) => void;
 };
 
 type ViewMode = "tasks" | "bosses";
@@ -117,6 +119,8 @@ export function CombatAchievementsPanel({
   onTypeFilterChange,
   completionFilter,
   onCompletionFilterChange,
+  hideCompletedBosses,
+  onHideCompletedBossesChange,
 }: CombatAchievementsPanelProps) {
   const [bossSearch, setBossSearch] = React.useState("");
   const [showMobileFilters, setShowMobileFilters] = React.useState(false);
@@ -183,13 +187,19 @@ export function CombatAchievementsPanel({
 
     bossList.sort((a, b) => a.name.localeCompare(b.name));
 
-    if (bossSearch.trim()) {
-      const query = bossSearch.trim().toLowerCase();
-      return bossList.filter((b) => b.name.toLowerCase().includes(query));
+    let filtered = bossList;
+
+    if (hideCompletedBosses) {
+      filtered = filtered.filter((b) => b.completedCount < b.totalCount);
     }
 
-    return bossList;
-  }, [completedSet, bossSearch]);
+    if (bossSearch.trim()) {
+      const query = bossSearch.trim().toLowerCase();
+      filtered = filtered.filter((b) => b.name.toLowerCase().includes(query));
+    }
+
+    return filtered;
+  }, [completedSet, bossSearch, hideCompletedBosses]);
 
   const handleBossClick = React.useCallback(
     (bossName: string) => {
@@ -260,13 +270,33 @@ export function CombatAchievementsPanel({
                 hasNextThreshold={!!nextThreshold}
               />
             ) : (
-              <input
-                type="text"
-                value={bossSearch}
-                onChange={(e) => setBossSearch(e.target.value)}
-                placeholder="Search..."
-                className="w-full h-[28px] bg-black/60 border-2 border-black rounded-sm px-2 text-[17px] text-osrs-white solid-text-shadow leading-none font-runescape placeholder:text-osrs-gray outline-none focus:border-osrs-orange/50"
-              />
+              <div className="flex items-center gap-1.5">
+                <input
+                  type="text"
+                  value={bossSearch}
+                  onChange={(e) => setBossSearch(e.target.value)}
+                  placeholder="Search..."
+                  className="flex-1 min-w-0 h-[28px] bg-black/60 border-2 border-black rounded-sm px-2 text-[17px] text-osrs-white solid-text-shadow leading-none font-runescape placeholder:text-osrs-gray outline-none focus:border-osrs-orange/50"
+                />
+                <button
+                  type="button"
+                  role="checkbox"
+                  aria-checked={hideCompletedBosses}
+                  onClick={() =>
+                    onHideCompletedBossesChange(!hideCompletedBosses)
+                  }
+                  className="h-[28px] shrink-0 flex items-center gap-1.5 bg-black/60 border-2 border-black rounded-sm px-2 text-[17px] text-osrs-orange solid-text-shadow leading-none hover:text-osrs-white cursor-pointer"
+                >
+                  <span className="size-[14px] shrink-0 border-2 border-black bg-black/60 flex items-center justify-center leading-none">
+                    {hideCompletedBosses && (
+                      <span className="text-osrs-green text-[14px] leading-none">
+                        &#10003;
+                      </span>
+                    )}
+                  </span>
+                  Hide completed
+                </button>
+              </div>
             )}
           </div>
         </div>

--- a/apps/web/src/routes/$username.tsx
+++ b/apps/web/src/routes/$username.tsx
@@ -89,6 +89,7 @@ const profileSearchSchema = z.object({
     .catch(undefined),
   "ca-type": z.enum(VALID_CA_TYPES).optional().catch(undefined),
   "ca-completed": z.enum(VALID_CA_COMPLETION).optional().catch(undefined),
+  "ca-hide-completed": z.coerce.boolean().optional().catch(undefined),
   "ca-panel": z.enum(VALID_PANELS).optional().catch(undefined),
 });
 
@@ -240,6 +241,12 @@ export function ProfileContent({
                 updateSearch({
                   "ca-completed":
                     caCompleted === "all" ? undefined : caCompleted,
+                })
+              }
+              hideCompletedBosses={search["ca-hide-completed"] ?? false}
+              onHideCompletedBossesChange={(hide) =>
+                updateSearch({
+                  "ca-hide-completed": hide ? true : undefined,
                 })
               }
             />


### PR DESCRIPTION
Very simple/quick filter to only show bosses that still have open tasks

Off
<img width="852" height="598" alt="image" src="https://github.com/user-attachments/assets/4b1f3716-2612-4947-a785-116d1fcadf02" />

On
<img width="865" height="607" alt="image" src="https://github.com/user-attachments/assets/537f285f-8ef7-4693-aea1-f2a4865ae28e" />

Obviously feel free to change/suggest a different label name or icon or whatever but this seems sort of in-line with the rest of the web app