### PR TITLE
perf(db): drop 7 redundant single-column indexes

### DIFF
--- a/packages/db/drizzle/0014_amazing_madame_masque.sql
+++ b/packages/db/drizzle/0014_amazing_madame_masque.sql
@@ -1,0 +1,7 @@
+DROP INDEX "activities_account_id_index";--> statement-breakpoint
+DROP INDEX "combat_achievement_tiers_account_id_index";--> statement-breakpoint
+DROP INDEX "discord_watch_filters_channel_index";--> statement-breakpoint
+DROP INDEX "discord_watches_channel_index";--> statement-breakpoint
+DROP INDEX "items_account_id_index";--> statement-breakpoint
+DROP INDEX "quests_account_id_index";--> statement-breakpoint
+DROP INDEX "skills_account_id_index";

--- a/packages/db/drizzle/meta/0014_snapshot.json
+++ b/packages/db/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1110 @@
+{
+  "id": "94372768-a745-49b6-a8f2-676b79e82d15",
+  "prevId": "2da9f990-d8ee-465d-b387-4bc4b49fc51b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_username": {
+          "name": "pending_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "clan_name": {
+          "name": "clan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clan_rank": {
+          "name": "clan_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clan_icon": {
+          "name": "clan_icon",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clan_title": {
+          "name": "clan_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_clog_page": {
+          "name": "default_clog_page",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "force_resync": {
+          "name": "force_resync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_username_unique_index": {
+          "name": "accounts_username_unique_index",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_pending_username_index": {
+          "name": "accounts_pending_username_index",
+          "columns": [
+            {
+              "expression": "lower(\"pending_username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_clan_name_index": {
+          "name": "accounts_clan_name_index",
+          "columns": [
+            {
+              "expression": "lower(\"clan_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_clan_name_id_index": {
+          "name": "accounts_clan_name_id_index",
+          "columns": [
+            {
+              "expression": "lower(\"clan_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_group_name_index": {
+          "name": "accounts_group_name_index",
+          "columns": [
+            {
+              "expression": "lower(\"group_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_clan_members_sorted_index": {
+          "name": "accounts_clan_members_sorted_index",
+          "columns": [
+            {
+              "expression": "lower(\"clan_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "clan_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.achievement_diary_tiers": {
+      "name": "achievement_diary_tiers",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "area_id": {
+          "name": "area_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "achievement_diary_tiers_account_id_accounts_id_fk": {
+          "name": "achievement_diary_tiers_account_id_accounts_id_fk",
+          "tableFrom": "achievement_diary_tiers",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "achievement_diary_tiers_account_id_area_id_tier_pk": {
+          "name": "achievement_diary_tiers_account_id_area_id_tier_pk",
+          "columns": [
+            "account_id",
+            "area_id",
+            "tier"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activities_account_id_created_at_id_desc_index": {
+          "name": "activities_account_id_created_at_id_desc_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_account_id_created_at_id_index": {
+          "name": "activities_account_id_created_at_id_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_account_id_type_created_at_index": {
+          "name": "activities_account_id_type_created_at_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activities_account_id_accounts_id_fk": {
+          "name": "activities_account_id_accounts_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique_index": {
+          "name": "api_keys_key_hash_unique_index",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clan_activities": {
+      "name": "clan_activities",
+      "schema": "",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clan_name": {
+          "name": "clan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clan_activities_name_created_at_id_desc_index": {
+          "name": "clan_activities_name_created_at_id_desc_index",
+          "columns": [
+            {
+              "expression": "clan_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clan_activities_name_type_created_at_id_desc_index": {
+          "name": "clan_activities_name_type_created_at_id_desc_index",
+          "columns": [
+            {
+              "expression": "clan_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clan_activities_activity_id_activities_id_fk": {
+          "name": "clan_activities_activity_id_activities_id_fk",
+          "tableFrom": "clan_activities",
+          "tableTo": "activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.combat_achievement_tiers": {
+      "name": "combat_achievement_tiers",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_count": {
+          "name": "completed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "combat_achievement_tiers_account_id_accounts_id_fk": {
+          "name": "combat_achievement_tiers_account_id_accounts_id_fk",
+          "tableFrom": "combat_achievement_tiers",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "combat_achievement_tiers_account_id_id_pk": {
+          "name": "combat_achievement_tiers_account_id_id_pk",
+          "columns": [
+            "account_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.combat_achievement_varps": {
+      "name": "combat_achievement_varps",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "varps": {
+          "name": "varps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "combat_achievement_varps_account_id_accounts_id_fk": {
+          "name": "combat_achievement_varps_account_id_accounts_id_fk",
+          "tableFrom": "combat_achievement_varps",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_users": {
+      "name": "discord_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rsn": {
+          "name": "rsn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_users_account_id_index": {
+          "name": "discord_users_account_id_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_users_rsn_index": {
+          "name": "discord_users_rsn_index",
+          "columns": [
+            {
+              "expression": "rsn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_users_account_id_accounts_id_fk": {
+          "name": "discord_users_account_id_accounts_id_fk",
+          "tableFrom": "discord_users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_watch_filters": {
+      "name": "discord_watch_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_watch_filters_channel_activity_unique_index": {
+          "name": "discord_watch_filters_channel_activity_unique_index",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_watches": {
+      "name": "discord_watches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_watches_channel_target_unique_index": {
+          "name": "discord_watches_channel_target_unique_index",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discord_watches_target_index": {
+          "name": "discord_watches_target_index",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "items_account_id_accounts_id_fk": {
+          "name": "items_account_id_accounts_id_fk",
+          "tableFrom": "items",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "items_account_id_id_pk": {
+          "name": "items_account_id_id_pk",
+          "columns": [
+            "account_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quests": {
+      "name": "quests",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quests_account_id_accounts_id_fk": {
+          "name": "quests_account_id_accounts_id_fk",
+          "tableFrom": "quests",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quests_account_id_id_pk": {
+          "name": "quests_account_id_id_pk",
+          "columns": [
+            "account_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp": {
+          "name": "xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skills_account_id_accounts_id_fk": {
+          "name": "skills_account_id_accounts_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "skills_account_id_name_pk": {
+          "name": "skills_account_id_name_pk",
+          "columns": [
+            "account_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1784047913473,
       "tag": "0013_freezing_pestilence",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1784048895431,
+      "tag": "0014_amazing_madame_masque",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -77,10 +77,7 @@ export const combatAchievementTiers = t.pgTable(
     id: t.integer().notNull(),
     completedCount: t.integer().notNull(),
   },
-  (table) => [
-    t.primaryKey({ columns: [table.accountId, table.id] }),
-    t.index("combat_achievement_tiers_account_id_index").on(table.accountId),
-  ],
+  (table) => [t.primaryKey({ columns: [table.accountId, table.id] })],
 );
 export const combatAchievementTiersRelations = relations(
   combatAchievementTiers,
@@ -117,10 +114,7 @@ export const items = t.pgTable(
     quantity: t.integer().notNull(),
     createdAt,
   },
-  (table) => [
-    t.primaryKey({ columns: [table.accountId, table.id] }),
-    t.index("items_account_id_index").on(table.accountId),
-  ],
+  (table) => [t.primaryKey({ columns: [table.accountId, table.id] })],
 );
 export const itemsRelations = relations(items, ({ one }) => ({
   account: one(accounts, {
@@ -136,10 +130,7 @@ export const quests = t.pgTable(
     id: t.integer().notNull(),
     state: t.integer().notNull(),
   },
-  (table) => [
-    t.primaryKey({ columns: [table.accountId, table.id] }),
-    t.index("quests_account_id_index").on(table.accountId),
-  ],
+  (table) => [t.primaryKey({ columns: [table.accountId, table.id] })],
 );
 export const questsRelations = relations(quests, ({ one }) => ({
   account: one(accounts, {
@@ -155,10 +146,7 @@ export const skills = t.pgTable(
     name: t.text().notNull(),
     xp: t.integer().notNull(),
   },
-  (table) => [
-    t.primaryKey({ columns: [table.accountId, table.name] }),
-    t.index("skills_account_id_index").on(table.accountId),
-  ],
+  (table) => [t.primaryKey({ columns: [table.accountId, table.name] })],
 );
 export const skillsRelations = relations(skills, ({ one }) => ({
   account: one(accounts, {
@@ -177,7 +165,6 @@ export const activities = t.pgTable(
     createdAt,
   },
   (table) => [
-    t.index("activities_account_id_index").on(table.accountId),
     t
       .index("activities_account_id_created_at_id_desc_index")
       .on(table.accountId, table.createdAt.desc(), table.id.desc()),
@@ -259,7 +246,6 @@ export const discordWatches = t.pgTable(
     t
       .uniqueIndex("discord_watches_channel_target_unique_index")
       .on(table.channelId, table.targetType, table.targetId),
-    t.index("discord_watches_channel_index").on(table.channelId),
     t
       .index("discord_watches_target_index")
       .on(table.targetType, table.targetId),
@@ -287,7 +273,6 @@ export const discordWatchFilters = t.pgTable(
     t
       .uniqueIndex("discord_watch_filters_channel_activity_unique_index")
       .on(table.channelId, table.activityType),
-    t.index("discord_watch_filters_channel_index").on(table.channelId),
   ],
 );
 


### PR DESCRIPTION
Implementing PlanetScale schema recommendation — this PR covers the full batch of duplicate-index recommendations:

- [#7](https://app.planetscale.com/runeprofile/profiles/insights/recommendations/7) / [#13](https://app.planetscale.com/runeprofile/profiles/insights/recommendations/13): `activities_account_id_index` (170 MB)
- [#8](https://app.planetscale.com/runeprofile/profiles/insights/recommendations/8): `combat_achievement_tiers_account_id_index` (17 MB)
- [#9](https://app.planetscale.com/runeprofile/profiles/insights/recommendations/9): `discord_watches_channel_index`
- [#10](https://app.planetscale.com/runeprofile/profiles/insights/recommendations/10): `items_account_id_index` (486 MB)
- [#11](https://app.planetscale.com/runeprofile/profiles/insights/recommendations/11): `quests_account_id_index` (258 MB)
- [#12](https://app.planetscale.com/runeprofile/profiles/insights/recommendations/12): `skills_account_id_index` (58 MB)
- [#15](https://app.planetscale.com/runeprofile/profiles/insights/recommendations/15) / [#16](https://app.planetscale.com/runeprofile/profiles/insights/recommendations/16): `discord_watch_filters_channel_index` (redundant *and* unused)

## What

- Removes the 7 index definitions from the Drizzle schema.
- Adds migration `0014_amazing_madame_masque.sql` with the corresponding `DROP INDEX` statements.

## Why

Each dropped index is a strict prefix of an existing composite primary key or unique index on the same table (verified against the live database), so every query it can serve is already served by the composite index. Together they hold ~1.1 GB and add one extra index write per row change on 7 hot tables.

`discord_users_account_id_index` was deliberately kept — it has no covering composite index and is not flagged by PlanetScale.

## Notes

- No application code references any of these index names; only the schema definition changed.
- Migration must be applied with `pnpm --filter @runeprofile/db db:apply:remote` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)