### PR TITLE
fix(scripts): report one clog item rename per item, not per page

### DIFF
--- a/scripts/ts-scripts/check-clog.ts
+++ b/scripts/ts-scripts/check-clog.ts
@@ -94,11 +94,15 @@ async function checkClog() {
   const removedPages: Array<{ tab: string; pageName: string }> = [];
 
   const newItems: Record<number, string> = {};
-  const changedItemNames: Array<{
-    id: number;
-    oldName: string;
-    newName: string;
-  }> = [];
+
+  // Keyed by item ID because the item loop below runs per page, and an item can
+  // sit on several pages (every pet is on its boss page and on Pets). The name
+  // comes from the item def, so every page agrees on it - keying by ID reports
+  // one rename per item instead of one per page it appears on.
+  const changedItemNamesById = new Map<
+    number,
+    { oldName: string; newName: string }
+  >();
 
   for (const tabId of tabIds) {
     const tabStruct = await cache.Struct.load(provider, tabId);
@@ -197,8 +201,7 @@ async function checkClog() {
             // Check if the name has changed (use the appropriate ID for lookup)
             const existingName = COLLECTION_LOG_ITEMS[itemIdToCheck];
             if (existingName !== itemName) {
-              changedItemNames.push({
-                id: itemIdToCheck,
+              changedItemNamesById.set(itemIdToCheck, {
                 oldName: existingName,
                 newName: itemName,
               });
@@ -312,6 +315,10 @@ async function checkClog() {
     }
   }
 
+  const changedItemNames = [...changedItemNamesById]
+    .map(([id, names]) => ({ id, ...names }))
+    .sort((a, b) => a.id - b.id);
+
   const hasChanges =
     pagesWithChanges.length > 0 ||
     reorderedTabs.length > 0 ||
@@ -397,8 +404,7 @@ async function checkClog() {
 
       if (changedItemNames.length > 0) {
         console.log("// NAME CHANGES - Update these in COLLECTION_LOG_ITEMS:");
-        const sortedChangedItems = changedItemNames.sort((a, b) => a.id - b.id);
-        for (const { id, oldName, newName } of sortedChangedItems) {
+        for (const { id, oldName, newName } of changedItemNames) {
           console.log(`  ${id}: "${newName}", // was: "${oldName}"`);
         }
         console.log("");
@@ -494,9 +500,8 @@ function buildChangeSummary(
   }
 
   if (changedItemNames.length > 0) {
-    const sorted = [...changedItemNames].sort((a, b) => a.id - b.id);
-    lines.push(`### Item Name Changes (${sorted.length})\n`);
-    for (const { id, oldName, newName } of sorted) {
+    lines.push(`### Item Name Changes (${changedItemNames.length})\n`);
+    for (const { id, oldName, newName } of changedItemNames) {
       lines.push(`- \`${id}\`: ~~${oldName}~~ → ${newName}`);
     }
     lines.push("");


### PR DESCRIPTION
The item loop in `check-clog.ts` runs per collection log page, so pushing renames into a flat array recorded one entry per *page* an item appears on rather than per item. Every pet sits on both its boss page and Pets, which is why [#39](https://github.com/ReinhardtR/runeprofile/pull/39) listed `Pet Chaos Elemental` three times and reported **57** name changes when there were only **33**.

Fix: collect into a `Map` keyed by item ID (the name comes from the item def, so every page agrees on it), and sort once at the source — which lets both consumers drop their own re-sort, one of which was mutating its caller's array.

The `--write` path was always correct, since it keyed into a map anyway. This only affects the generated PR body.

Verified by running `pnpm check-clog` against the cache mirror, reproducing #39's dataset:

```
### Item Name Changes (33)
```

One row per item, still ID-sorted, no repeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)