### PR TITLE
feat(admin): bulk-resolve stale pending names and surface name conflicts in account search

### DIFF
--- a/apps/admin/app/accounts/ResultsTable.tsx
+++ b/apps/admin/app/accounts/ResultsTable.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { CopyButton } from "@/components/copy-button";
+import {
+  ClearButton,
+  ResolveDialog,
+  formatIdle,
+} from "@/components/pending-name-actions";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -10,7 +15,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Ban } from "lucide-react";
+import { isStaleHolder } from "@/lib/pending-names";
+import { Ban, TriangleAlert } from "lucide-react";
 import Link from "next/link";
 
 import { DeleteDialog } from "./DeleteDialog";
@@ -28,6 +34,59 @@ interface AccountRow {
   groupName: string | null;
   forceResync: boolean;
   updatedAt: string;
+  pendingUsername: string | null;
+  holderUsername: string | null;
+  holderUpdatedAt: string | null;
+}
+
+function ConflictCell({ row }: { row: AccountRow }) {
+  if (!row.pendingUsername) {
+    return <span className="text-muted-foreground text-sm">—</span>;
+  }
+  const stale = isStaleHolder(row.holderUpdatedAt);
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-1 text-sm">
+        <TriangleAlert
+          className={`h-4 w-4 ${stale ? "text-amber-600" : "text-destructive"}`}
+        />
+        wants{" "}
+        <span className="font-mono font-medium">{row.pendingUsername}</span>
+      </div>
+      <div className="text-xs text-muted-foreground" suppressHydrationWarning>
+        {row.holderUsername ? (
+          <>
+            held by{" "}
+            <a
+              href={`https://runeprofile.com/${encodeURIComponent(row.holderUsername)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono underline decoration-dotted underline-offset-2"
+            >
+              {row.holderUsername}
+            </a>
+            {row.holderUpdatedAt && ` · ${formatIdle(row.holderUpdatedAt)}`}
+            {stale && " · stale"}
+          </>
+        ) : (
+          "name is free"
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <ResolveDialog
+          row={{
+            id: row.id,
+            username: row.username,
+            pendingUsername: row.pendingUsername,
+            updatedAt: row.updatedAt,
+            holderUsername: row.holderUsername,
+            holderUpdatedAt: row.holderUpdatedAt,
+          }}
+        />
+        <ClearButton row={row} />
+      </div>
+    </div>
+  );
 }
 
 export function ResultsTable({
@@ -45,6 +104,7 @@ export function ResultsTable({
           <TableHead>Username</TableHead>
           <TableHead>Clan</TableHead>
           <TableHead>Last Updated</TableHead>
+          <TableHead>Name Conflict</TableHead>
           <TableHead>Actions</TableHead>
         </TableRow>
       </TableHeader>
@@ -104,6 +164,9 @@ export function ResultsTable({
                   "N/A"
                 )}
               </div>
+            </TableCell>
+            <TableCell className="align-top">
+              <ConflictCell row={r} />
             </TableCell>
             <TableCell>
               <div className="flex items-center gap-2 flex-wrap">

--- a/apps/admin/app/accounts/actions.ts
+++ b/apps/admin/app/accounts/actions.ts
@@ -3,6 +3,7 @@
 import { db } from "@/lib/db";
 import { invalidateDiffCache } from "@/lib/invalidate-diff-cache";
 import { createPetModelKey, createPlayerModelKey } from "@/lib/model-keys";
+import { holder, holderJoin } from "@/lib/pending-names.server";
 import { requireAdmin } from "@/lib/require-admin";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { eq, like, sql } from "drizzle-orm";
@@ -156,6 +157,10 @@ export async function searchAccounts(q: string) {
     groupName: accounts.groupName,
     forceResync: accounts.forceResync,
     updatedAt: accounts.updatedAt,
+    // Name conflict: the name this account wants, and who currently holds it.
+    pendingUsername: accounts.pendingUsername,
+    holderUsername: holder.username,
+    holderUpdatedAt: holder.updatedAt,
   };
 
   // If it looks like a full UUID, search by id.
@@ -163,6 +168,7 @@ export async function searchAccounts(q: string) {
     return db
       .select(selectFields)
       .from(accounts)
+      .leftJoin(holder, holderJoin)
       .where(eq(accounts.id, raw))
       .limit(1);
   }
@@ -172,6 +178,7 @@ export async function searchAccounts(q: string) {
     return db
       .select(selectFields)
       .from(accounts)
+      .leftJoin(holder, holderJoin)
       .where(like(accounts.id, `${raw}%`))
       .limit(25);
   }
@@ -182,6 +189,7 @@ export async function searchAccounts(q: string) {
   return db
     .select(selectFields)
     .from(accounts)
+    .leftJoin(holder, holderJoin)
     .where(sql`lower(${accounts.username}) like ${`%${term}%`}`)
     .orderBy(
       sql`CASE

--- a/apps/admin/app/pending-names/PendingNamesTable.tsx
+++ b/apps/admin/app/pending-names/PendingNamesTable.tsx
@@ -1,16 +1,10 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+  ClearButton,
+  ResolveDialog,
+  formatIdle,
+} from "@/components/pending-name-actions";
 import {
   Table,
   TableBody,
@@ -19,23 +13,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { LoaderCircle } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-
-import {
-  clearPendingName,
-  type PendingNameRow,
-  resolvePendingName,
-} from "./actions";
-
-function formatIdle(since: string | null): string {
-  if (!since) return "";
-  const days = Math.floor((Date.now() - new Date(since).getTime()) / 86400000);
-  if (days < 1) return "today";
-  if (days < 31) return `${days}d idle`;
-  return `${Math.floor(days / 30)}mo idle`;
-}
+import { type PendingNameRow, isStaleHolder } from "@/lib/pending-names";
 
 function SyncTime({ value }: { value: string | null }) {
   if (!value) return <span className="text-muted-foreground">N/A</span>;
@@ -47,112 +25,6 @@ function SyncTime({ value }: { value: string | null }) {
     >
       {new Date(value).toLocaleString()}
     </time>
-  );
-}
-
-function ResolveDialog({ row }: { row: PendingNameRow }) {
-  const router = useRouter();
-  const [open, setOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState("");
-
-  const handleResolve = async () => {
-    setIsLoading(true);
-    setError("");
-    try {
-      await resolvePendingName(row.id);
-      setOpen(false);
-      router.refresh();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to resolve");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button type="button" size="sm">
-          Resolve
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Grant pending name</DialogTitle>
-          <DialogDescription asChild>
-            <div className="space-y-2">
-              <p>
-                <span className="font-mono font-bold">{row.username}</span>{" "}
-                will be renamed to{" "}
-                <span className="font-mono font-bold">
-                  {row.pendingUsername}
-                </span>
-                .
-              </p>
-              {row.holderUsername ? (
-                <p>
-                  The current holder{" "}
-                  <span className="font-mono font-bold">
-                    {row.holderUsername}
-                  </span>{" "}
-                  (last sync{" "}
-                  {row.holderUpdatedAt
-                    ? new Date(row.holderUpdatedAt).toLocaleString()
-                    : "unknown"}
-                  ) will be archived under a placeholder.
-                </p>
-              ) : (
-                <p>The name is free — no other account is affected.</p>
-              )}
-            </div>
-          </DialogDescription>
-        </DialogHeader>
-        {error && <div className="text-sm text-destructive">{error}</div>}
-        <DialogFooter>
-          <DialogClose asChild>
-            <Button type="button" variant="outline" disabled={isLoading}>
-              Cancel
-            </Button>
-          </DialogClose>
-          <Button type="button" size="sm" disabled={isLoading} onClick={handleResolve}>
-            {isLoading ? (
-              <span className="flex items-center gap-2">
-                <LoaderCircle className="animate-spin h-4 w-4" />
-                Resolving...
-              </span>
-            ) : (
-              "Resolve"
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function ClearButton({ row }: { row: PendingNameRow }) {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-
-  return (
-    <Button
-      type="button"
-      size="sm"
-      variant="outline"
-      disabled={isLoading}
-      onClick={async () => {
-        setIsLoading(true);
-        try {
-          await clearPendingName(row.id);
-          router.refresh();
-        } finally {
-          setIsLoading(false);
-        }
-      }}
-    >
-      {isLoading ? <LoaderCircle className="animate-spin h-4 w-4" /> : "Clear"}
-    </Button>
   );
 }
 
@@ -211,10 +83,11 @@ export function PendingNamesTable({ rows }: { rows: PendingNameRow[] }) {
                 <div className="space-y-0.5">
                   <SyncTime value={r.holderUpdatedAt} />
                   <div
-                    className="text-xs text-muted-foreground"
+                    className={`text-xs ${isStaleHolder(r.holderUpdatedAt) ? "text-amber-600" : "text-muted-foreground"}`}
                     suppressHydrationWarning
                   >
                     {formatIdle(r.holderUpdatedAt)}
+                    {isStaleHolder(r.holderUpdatedAt) && " · stale"}
                   </div>
                 </div>
               ) : (

--- a/apps/admin/app/pending-names/actions.ts
+++ b/apps/admin/app/pending-names/actions.ts
@@ -1,45 +1,27 @@
 "use server";
 
 import { db } from "@/lib/db";
-import { invalidateDiffCache } from "@/lib/invalidate-diff-cache";
+import { type PendingNameRow } from "@/lib/pending-names";
+import {
+  findStalePendingNames,
+  grantPendingName,
+  holder,
+  holderJoin,
+  pendingNameFields,
+} from "@/lib/pending-names.server";
 import { requireAdmin } from "@/lib/require-admin";
-import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { aliasedTable, and, eq, isNotNull, ne, sql } from "drizzle-orm";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 
-import { accounts, lower } from "@runeprofile/db";
-import { placeholderUsername } from "@runeprofile/runescape";
-
-export type PendingNameRow = {
-  id: string;
-  username: string;
-  pendingUsername: string;
-  updatedAt: string;
-  holderUsername: string | null;
-  holderUpdatedAt: string | null;
-};
+import { accounts } from "@runeprofile/db";
 
 export async function getPendingNames(): Promise<PendingNameRow[]> {
   await requireAdmin();
 
-  const holder = aliasedTable(accounts, "holder");
   const rows = await db
-    .select({
-      id: accounts.id,
-      username: accounts.username,
-      pendingUsername: accounts.pendingUsername,
-      updatedAt: accounts.updatedAt,
-      holderUsername: holder.username,
-      holderUpdatedAt: holder.updatedAt,
-    })
+    .select(pendingNameFields)
     .from(accounts)
-    .leftJoin(
-      holder,
-      and(
-        eq(lower(holder.username), lower(accounts.pendingUsername)),
-        ne(holder.id, accounts.id),
-      ),
-    )
+    .leftJoin(holder, holderJoin)
     .where(isNotNull(accounts.pendingUsername))
     // Free names first (grantable without archiving anyone), then the holders
     // that have been dead the longest.
@@ -48,90 +30,68 @@ export async function getPendingNames(): Promise<PendingNameRow[]> {
   return rows as PendingNameRow[];
 }
 
-/**
- * Grants an account its pending username. If another row still holds the name,
- * it is archived under a placeholder first (same convention as the Archive
- * button) — only use this when you're confident the holder is a stale row.
- *
- * Mirrors the API's rename bookkeeping: R2 models move with the username and
- * both diff caches are invalidated. No freed-name cascade is needed here — a
- * row pending on the claimant's old name picks it up on its own next sync.
- */
+/** See `grantPendingName`. */
 export async function resolvePendingName(claimantId: string) {
   await requireAdmin();
 
-  const claimant = await db.query.accounts.findFirst({
-    where: eq(accounts.id, claimantId),
-    columns: { id: true, username: true, pendingUsername: true },
-  });
-  if (!claimant) {
-    throw new Error("Account not found");
-  }
-  const wanted = claimant.pendingUsername;
-  if (!wanted) {
-    throw new Error("Account has no pending username");
-  }
-
-  const holder = await db.query.accounts.findFirst({
-    where: and(
-      eq(lower(accounts.username), wanted.toLowerCase()),
-      ne(accounts.id, claimant.id),
-    ),
-    columns: { id: true, username: true },
-  });
-
-  const holderPlaceholder = placeholderUsername();
-
-  await db.transaction(async (tx) => {
-    if (holder) {
-      // Free the name first so the unique index never collides mid-move.
-      const archived = await tx
-        .update(accounts)
-        .set({
-          username: holderPlaceholder,
-          clanName: null,
-          clanRank: null,
-          clanIcon: null,
-          clanTitle: null,
-          groupName: null,
-        })
-        .where(
-          and(eq(accounts.id, holder.id), eq(accounts.username, holder.username)),
-        )
-        .returning({ id: accounts.id });
-      if (archived.length === 0) {
-        throw new Error("Holder row changed concurrently, aborting");
-      }
-    }
-
-    const granted = await tx
-      .update(accounts)
-      .set({ username: wanted, pendingUsername: null })
-      .where(
-        and(
-          eq(accounts.id, claimant.id),
-          eq(accounts.pendingUsername, wanted),
-        ),
-      )
-      .returning({ id: accounts.id });
-    if (granted.length === 0) {
-      throw new Error("Claimant row changed concurrently, aborting");
-    }
-  });
-
-  const bucket = getCloudflareContext().env.BUCKET;
-  await Promise.all([
-    renameModelFiles(bucket, claimant.username, wanted),
-    invalidateDiffCache(claimant.id),
-    ...(holder
-      ? [
-          renameModelFiles(bucket, holder.username, holderPlaceholder),
-          invalidateDiffCache(holder.id),
-        ]
-      : []),
-  ]);
+  await grantPendingName(claimantId);
 
   revalidatePath("/pending-names");
+  revalidatePath("/accounts");
+}
+
+// Each grant costs a transaction plus up to four R2 moves and two KV deletes;
+// keep one action well inside Worker subrequest/CPU limits.
+const STALE_BATCH_SIZE = 25;
+
+export type ResolveStaleResult = {
+  resolved: { username: string; pendingUsername: string }[];
+  failed: { username: string; pendingUsername: string; error: string }[];
+  /** Stale claims still left after this batch (0 when finished). */
+  remaining: number;
+};
+
+/**
+ * Grants every pending name whose holder has been inactive for at least
+ * STALE_HOLDER_DAYS, one batch at a time. Claims are processed sequentially so
+ * a chain (A wants B's name, B wants C's) settles in order.
+ */
+export async function resolveStalePendingNames(): Promise<ResolveStaleResult> {
+  await requireAdmin();
+
+  const batch = await findStalePendingNames(STALE_BATCH_SIZE);
+  const result: ResolveStaleResult = { resolved: [], failed: [], remaining: 0 };
+
+  for (const row of batch) {
+    try {
+      await grantPendingName(row.id);
+      result.resolved.push({
+        username: row.username,
+        pendingUsername: row.pendingUsername,
+      });
+    } catch (err) {
+      result.failed.push({
+        username: row.username,
+        pendingUsername: row.pendingUsername,
+        error: err instanceof Error ? err.message : "Failed to resolve",
+      });
+    }
+  }
+
+  const remaining = await findStalePendingNames(STALE_BATCH_SIZE + 1);
+  // Rows that failed this round would be counted again; report only new work.
+  result.remaining = Math.max(0, remaining.length - result.failed.length);
+
+  console.log({
+    event: "stale-pending-names-resolved",
+    resolved: result.resolved.length,
+    failed: result.failed.length,
+    remaining: result.remaining,
+  });
+
+  revalidatePath("/pending-names");
+  revalidatePath("/accounts");
+  return result;
 }
 
 /**
@@ -144,34 +104,10 @@ export async function clearPendingName(claimantId: string) {
   await db
     .update(accounts)
     .set({ pendingUsername: null })
-    .where(and(eq(accounts.id, claimantId), isNotNull(accounts.pendingUsername)));
+    .where(
+      and(eq(accounts.id, claimantId), isNotNull(accounts.pendingUsername)),
+    );
 
   revalidatePath("/pending-names");
-}
-
-async function renameModelFiles(
-  bucket: R2Bucket,
-  oldUsername: string,
-  newUsername: string,
-) {
-  const oldKey = oldUsername.toLowerCase();
-  const newKey = newUsername.toLowerCase();
-  if (oldKey === newKey) return;
-
-  try {
-    await Promise.all([
-      renameFile(bucket, oldKey, newKey),
-      renameFile(bucket, `${oldKey}-pet`, `${newKey}-pet`),
-    ]);
-  } catch {
-    console.error("Failed to rename model files");
-  }
-}
-
-async function renameFile(bucket: R2Bucket, oldKey: string, newKey: string) {
-  const file = await bucket.get(oldKey);
-  if (!file) return;
-  const data = await file.arrayBuffer();
-  await bucket.put(newKey, data);
-  await bucket.delete(oldKey);
+  revalidatePath("/accounts");
 }

--- a/apps/admin/app/pending-names/page.tsx
+++ b/apps/admin/app/pending-names/page.tsx
@@ -1,4 +1,6 @@
+import { ResolveStaleDialog } from "@/components/pending-name-actions";
 import { Card } from "@/components/ui/card";
+import { STALE_HOLDER_DAYS, isStaleHolder } from "@/lib/pending-names";
 
 import { PendingNamesTable } from "./PendingNamesTable";
 import { getPendingNames } from "./actions";
@@ -8,28 +10,42 @@ export const dynamic = "force-dynamic";
 export default async function PendingNamesPage() {
   const rows = await getPendingNames();
   const freeCount = rows.filter((r) => !r.holderUsername).length;
+  const staleCount = rows.filter(
+    (r) => r.holderUsername && isStaleHolder(r.holderUpdatedAt),
+  ).length;
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold tracking-tight">Pending Names</h1>
       <Card className="p-4 space-y-4">
         <p className="text-sm text-muted-foreground">
-          Accounts waiting on a username held by another row. The plugin
-          reports an account&apos;s actual in-game name, so a claimant with a
-          long-idle holder is almost certainly the name&apos;s current owner.
-          Resolve archives the holder under a placeholder and grants the name;
-          Clear drops the claim (it reappears if the claimant syncs with the
-          same name).
+          Accounts waiting on a username held by another row. The plugin reports
+          an account&apos;s actual in-game name, so a claimant with a long-idle
+          holder is almost certainly the name&apos;s current owner. Resolve
+          archives the holder under a placeholder and grants the name; Clear
+          drops the claim (it reappears if the claimant syncs with the same
+          name). Resolve stale does this for every holder idle for{" "}
+          {STALE_HOLDER_DAYS}+ days.
         </p>
-        <p className="text-sm">
-          <span className="font-medium">{rows.length}</span> pending
-          {freeCount > 0 && (
-            <>
-              {" "}
-              · <span className="font-medium">{freeCount}</span> grantable
-              without archiving
-            </>
-          )}
-        </p>
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm">
+            <span className="font-medium">{rows.length}</span> pending
+            {freeCount > 0 && (
+              <>
+                {" "}
+                · <span className="font-medium">{freeCount}</span> grantable
+                without archiving
+              </>
+            )}
+            {staleCount > 0 && (
+              <>
+                {" "}
+                · <span className="font-medium">{staleCount}</span> with a stale
+                holder
+              </>
+            )}
+          </p>
+          <ResolveStaleDialog staleCount={staleCount} />
+        </div>
         {rows.length === 0 ? (
           <p className="text-neutral-500 text-sm">No pending names.</p>
         ) : (

--- a/apps/admin/components/pending-name-actions.tsx
+++ b/apps/admin/components/pending-name-actions.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import {
+  type ResolveStaleResult,
+  clearPendingName,
+  resolvePendingName,
+  resolveStalePendingNames,
+} from "@/app/pending-names/actions";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { type PendingNameRow, STALE_HOLDER_DAYS } from "@/lib/pending-names";
+import { LoaderCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export function formatIdle(since: string | null): string {
+  if (!since) return "";
+  const days = Math.floor((Date.now() - new Date(since).getTime()) / 86400000);
+  if (days < 1) return "today";
+  if (days < 31) return `${days}d idle`;
+  return `${Math.floor(days / 30)}mo idle`;
+}
+
+export function ResolveDialog({ row }: { row: PendingNameRow }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleResolve = async () => {
+    setIsLoading(true);
+    setError("");
+    try {
+      await resolvePendingName(row.id);
+      setOpen(false);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to resolve");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type="button" size="sm">
+          Resolve
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Grant pending name</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                <span className="font-mono font-bold">{row.username}</span> will
+                be renamed to{" "}
+                <span className="font-mono font-bold">
+                  {row.pendingUsername}
+                </span>
+                .
+              </p>
+              {row.holderUsername ? (
+                <p>
+                  The current holder{" "}
+                  <span className="font-mono font-bold">
+                    {row.holderUsername}
+                  </span>{" "}
+                  (last sync{" "}
+                  {row.holderUpdatedAt
+                    ? new Date(row.holderUpdatedAt).toLocaleString()
+                    : "unknown"}
+                  ) will be archived under a placeholder.
+                </p>
+              ) : (
+                <p>The name is free — no other account is affected.</p>
+              )}
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        {error && <div className="text-sm text-destructive">{error}</div>}
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isLoading}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            type="button"
+            size="sm"
+            disabled={isLoading}
+            onClick={handleResolve}
+          >
+            {isLoading ? (
+              <span className="flex items-center gap-2">
+                <LoaderCircle className="animate-spin h-4 w-4" />
+                Resolving...
+              </span>
+            ) : (
+              "Resolve"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function ClearButton({ row }: { row: Pick<PendingNameRow, "id"> }) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      disabled={isLoading}
+      onClick={async () => {
+        setIsLoading(true);
+        try {
+          await clearPendingName(row.id);
+          router.refresh();
+        } finally {
+          setIsLoading(false);
+        }
+      }}
+    >
+      {isLoading ? <LoaderCircle className="animate-spin h-4 w-4" /> : "Clear"}
+    </Button>
+  );
+}
+
+/**
+ * Resolves every claim whose holder is idle for STALE_HOLDER_DAYS+. Runs in
+ * batches; the dialog stays open with a summary until the admin closes it.
+ */
+export function ResolveStaleDialog({ staleCount }: { staleCount: number }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<ResolveStaleResult | null>(null);
+
+  const handleRun = async () => {
+    setIsLoading(true);
+    setError("");
+    try {
+      const next = await resolveStalePendingNames();
+      setResult((prev) =>
+        prev
+          ? {
+              resolved: [...prev.resolved, ...next.resolved],
+              failed: [...prev.failed, ...next.failed],
+              remaining: next.remaining,
+            }
+          : next,
+      );
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to resolve");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleOpenChange = (value: boolean) => {
+    if (isLoading) return;
+    setOpen(value);
+    if (!value) {
+      setResult(null);
+      setError("");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button type="button" size="sm" disabled={staleCount === 0}>
+          Resolve stale ({staleCount})
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Resolve stale pending names</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                Grants every pending name whose current holder has not synced
+                for {STALE_HOLDER_DAYS}+ days. Each holder is archived under a
+                placeholder. Claims on free names and on recently active holders
+                are left alone.
+              </p>
+              <p>
+                <span className="font-medium">{staleCount}</span> claim
+                {staleCount === 1 ? "" : "s"} qualify right now.
+              </p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        {result && (
+          <div className="space-y-2 text-sm">
+            <p>
+              Resolved{" "}
+              <span className="font-medium">{result.resolved.length}</span>
+              {result.failed.length > 0 && (
+                <>
+                  , failed{" "}
+                  <span className="font-medium text-destructive">
+                    {result.failed.length}
+                  </span>
+                </>
+              )}
+              {result.remaining > 0 && (
+                <>
+                  , <span className="font-medium">{result.remaining}</span>{" "}
+                  still waiting
+                </>
+              )}
+              .
+            </p>
+            {result.resolved.length > 0 && (
+              <ul className="max-h-40 overflow-y-auto font-mono text-xs space-y-0.5">
+                {result.resolved.map((r) => (
+                  <li key={`${r.username}->${r.pendingUsername}`}>
+                    {r.username} → {r.pendingUsername}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {result.failed.length > 0 && (
+              <ul className="max-h-40 overflow-y-auto text-xs space-y-0.5 text-destructive">
+                {result.failed.map((f) => (
+                  <li key={`${f.username}->${f.pendingUsername}`}>
+                    <span className="font-mono">
+                      {f.username} → {f.pendingUsername}
+                    </span>
+                    : {f.error}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+        {error && <div className="text-sm text-destructive">{error}</div>}
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isLoading}>
+              {result ? "Close" : "Cancel"}
+            </Button>
+          </DialogClose>
+          {(!result || result.remaining > 0) && (
+            <Button
+              type="button"
+              size="sm"
+              disabled={isLoading}
+              onClick={handleRun}
+            >
+              {isLoading ? (
+                <span className="flex items-center gap-2">
+                  <LoaderCircle className="animate-spin h-4 w-4" />
+                  Resolving...
+                </span>
+              ) : result ? (
+                `Resolve next ${Math.min(result.remaining, 25)}`
+              ) : (
+                "Resolve all stale"
+              )}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/lib/pending-names.server.ts
+++ b/apps/admin/lib/pending-names.server.ts
@@ -34,7 +34,7 @@ export async function findStalePendingNames(limit: number) {
     .where(
       and(
         isNotNull(accounts.pendingUsername),
-        sql`${holder.updatedAt} < now() - make_interval(days => ${STALE_HOLDER_DAYS})`,
+        sql`${holder.updatedAt} < now() - ${sql.raw(`interval '${STALE_HOLDER_DAYS} days'`)}`,
       ),
     )
     .orderBy(sql`${holder.updatedAt} ASC`)

--- a/apps/admin/lib/pending-names.server.ts
+++ b/apps/admin/lib/pending-names.server.ts
@@ -1,0 +1,154 @@
+import { db } from "@/lib/db";
+import { invalidateDiffCache } from "@/lib/invalidate-diff-cache";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { aliasedTable, and, eq, isNotNull, ne, sql } from "drizzle-orm";
+
+import { accounts, lower } from "@runeprofile/db";
+import { placeholderUsername } from "@runeprofile/runescape";
+
+import { type PendingNameRow, STALE_HOLDER_DAYS } from "./pending-names";
+
+export const holder = aliasedTable(accounts, "holder");
+
+/** Join condition: the row currently holding `accounts.pendingUsername`. */
+export const holderJoin = and(
+  eq(lower(holder.username), lower(accounts.pendingUsername)),
+  ne(holder.id, accounts.id),
+);
+
+export const pendingNameFields = {
+  id: accounts.id,
+  username: accounts.username,
+  pendingUsername: accounts.pendingUsername,
+  updatedAt: accounts.updatedAt,
+  holderUsername: holder.username,
+  holderUpdatedAt: holder.updatedAt,
+};
+
+/** Pending claims whose holder has not synced for STALE_HOLDER_DAYS. */
+export async function findStalePendingNames(limit: number) {
+  const rows = await db
+    .select(pendingNameFields)
+    .from(accounts)
+    .innerJoin(holder, holderJoin)
+    .where(
+      and(
+        isNotNull(accounts.pendingUsername),
+        sql`${holder.updatedAt} < now() - make_interval(days => ${STALE_HOLDER_DAYS})`,
+      ),
+    )
+    .orderBy(sql`${holder.updatedAt} ASC`)
+    .limit(limit);
+  return rows as PendingNameRow[];
+}
+
+/**
+ * Grants an account its pending username. If another row still holds the name,
+ * it is archived under a placeholder first (same convention as the Archive
+ * button) — only use this when you're confident the holder is a stale row.
+ *
+ * Mirrors the API's rename bookkeeping: R2 models move with the username and
+ * both diff caches are invalidated. No freed-name cascade is needed here — a
+ * row pending on the claimant's old name picks it up on its own next sync.
+ *
+ * Callers are responsible for `requireAdmin()`.
+ */
+export async function grantPendingName(claimantId: string) {
+  const claimant = await db.query.accounts.findFirst({
+    where: eq(accounts.id, claimantId),
+    columns: { id: true, username: true, pendingUsername: true },
+  });
+  if (!claimant) {
+    throw new Error("Account not found");
+  }
+  const wanted = claimant.pendingUsername;
+  if (!wanted) {
+    throw new Error("Account has no pending username");
+  }
+
+  const current = await db.query.accounts.findFirst({
+    where: and(
+      eq(lower(accounts.username), wanted.toLowerCase()),
+      ne(accounts.id, claimant.id),
+    ),
+    columns: { id: true, username: true },
+  });
+
+  const holderPlaceholder = placeholderUsername();
+
+  await db.transaction(async (tx) => {
+    if (current) {
+      // Free the name first so the unique index never collides mid-move.
+      const archived = await tx
+        .update(accounts)
+        .set({
+          username: holderPlaceholder,
+          clanName: null,
+          clanRank: null,
+          clanIcon: null,
+          clanTitle: null,
+          groupName: null,
+        })
+        .where(
+          and(
+            eq(accounts.id, current.id),
+            eq(accounts.username, current.username),
+          ),
+        )
+        .returning({ id: accounts.id });
+      if (archived.length === 0) {
+        throw new Error("Holder row changed concurrently, aborting");
+      }
+    }
+
+    const granted = await tx
+      .update(accounts)
+      .set({ username: wanted, pendingUsername: null })
+      .where(
+        and(eq(accounts.id, claimant.id), eq(accounts.pendingUsername, wanted)),
+      )
+      .returning({ id: accounts.id });
+    if (granted.length === 0) {
+      throw new Error("Claimant row changed concurrently, aborting");
+    }
+  });
+
+  const bucket = getCloudflareContext().env.BUCKET;
+  await Promise.all([
+    renameModelFiles(bucket, claimant.username, wanted),
+    invalidateDiffCache(claimant.id),
+    ...(current
+      ? [
+          renameModelFiles(bucket, current.username, holderPlaceholder),
+          invalidateDiffCache(current.id),
+        ]
+      : []),
+  ]);
+}
+
+async function renameModelFiles(
+  bucket: R2Bucket,
+  oldUsername: string,
+  newUsername: string,
+) {
+  const oldKey = oldUsername.toLowerCase();
+  const newKey = newUsername.toLowerCase();
+  if (oldKey === newKey) return;
+
+  try {
+    await Promise.all([
+      renameFile(bucket, oldKey, newKey),
+      renameFile(bucket, `${oldKey}-pet`, `${newKey}-pet`),
+    ]);
+  } catch {
+    console.error("Failed to rename model files");
+  }
+}
+
+async function renameFile(bucket: R2Bucket, oldKey: string, newKey: string) {
+  const file = await bucket.get(oldKey);
+  if (!file) return;
+  const data = await file.arrayBuffer();
+  await bucket.put(newKey, data);
+  await bucket.delete(oldKey);
+}

--- a/apps/admin/lib/pending-names.ts
+++ b/apps/admin/lib/pending-names.ts
@@ -1,0 +1,22 @@
+// Client-safe half of the pending-names helpers; DB access lives in
+// `pending-names.server.ts`.
+
+/** Days without a sync after which a name holder counts as inactive. */
+export const STALE_HOLDER_DAYS = 30;
+
+export type PendingNameRow = {
+  id: string;
+  username: string;
+  pendingUsername: string;
+  updatedAt: string;
+  holderUsername: string | null;
+  holderUpdatedAt: string | null;
+};
+
+export function isStaleHolder(holderUpdatedAt: string | null): boolean {
+  if (!holderUpdatedAt) return false;
+  return (
+    Date.now() - new Date(holderUpdatedAt).getTime() >=
+    STALE_HOLDER_DAYS * 86400000
+  );
+}


### PR DESCRIPTION
## What

- **Pending Names**: new **Resolve stale (N)** button. Grants every pending name whose current holder has not synced for 30+ days, archiving the holder under a placeholder (same path as the single Resolve). Runs in batches of 25 with a per-run summary and a "Resolve next" button until none remain. Claims on free names or on recently active holders are left alone. Stale holders are flagged in the table.
- **Account search**: results now join the current holder and show a **Name Conflict** column (wanted name, holder, idle time / "name is free") with the same Resolve / Clear controls.
- The single-row grant logic moved to `lib/pending-names.server.ts` so both actions share it; client-safe helpers (`PendingNameRow`, `STALE_HOLDER_DAYS`, `isStaleHolder`) live in `lib/pending-names.ts`.

## Verification

- Guard parity: every exported server action starts with `requireAdmin()` (incl. the new `resolveStalePendingNames`).
- No secret / `NEXT_PUBLIC` grep hits.
- `npx tsc --noEmit` clean, `pnpm build` passes, lint only has pre-existing warnings in untouched files.
- Not exercised against the production database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)