### PR TITLE
feat(api): evict stale username holders at claim time + sweep for parked claims

### DIFF
--- a/apps/admin/lib/pending-names.ts
+++ b/apps/admin/lib/pending-names.ts
@@ -1,8 +1,6 @@
 // Client-safe half of the pending-names helpers; DB access lives in
 // `pending-names.server.ts`.
-
-/** Days without a sync after which a name holder counts as inactive. */
-export const STALE_HOLDER_DAYS = 30;
+export { STALE_HOLDER_DAYS, isStaleHolder } from "@runeprofile/runescape";
 
 export type PendingNameRow = {
   id: string;
@@ -12,11 +10,3 @@ export type PendingNameRow = {
   holderUsername: string | null;
   holderUpdatedAt: string | null;
 };
-
-export function isStaleHolder(holderUpdatedAt: string | null): boolean {
-  if (!holderUpdatedAt) return false;
-  return (
-    Date.now() - new Date(holderUpdatedAt).getTime() >=
-    STALE_HOLDER_DAYS * 86400000
-  );
-}

--- a/apps/api/src/lib/profiles/resolve-username.test.ts
+++ b/apps/api/src/lib/profiles/resolve-username.test.ts
@@ -10,6 +10,7 @@ import {
   isUsernameUniqueViolation,
   resolveUsername,
 } from "~/lib/profiles/resolve-username";
+import { sweepStalePendingNames } from "~/lib/profiles/sweep-stale-names";
 
 // In-memory Postgres with just the accounts table — the resolution logic
 // only ever touches accounts.
@@ -43,6 +44,21 @@ async function getRow(id: string) {
 
 async function seed(id: string, username: string) {
   await db.insert(accounts).values({ id, username, accountType: 0 });
+}
+
+const DAY = 86400000;
+
+/** Backdates a row's last sync by `days`, as an account that stopped syncing. */
+async function lastSynced(id: string, daysAgo: number) {
+  await db
+    .update(accounts)
+    .set({ updatedAt: new Date(Date.now() - daysAgo * DAY).toISOString() })
+    .where(eq(accounts.id, id));
+}
+
+async function getFullRow(id: string) {
+  const rows = await db.select().from(accounts).where(eq(accounts.id, id));
+  return rows[0] ?? null;
 }
 
 // Mimics the POST /profiles flow: resolve, apply the resolution to the
@@ -224,9 +240,18 @@ describe("resolveUsername", () => {
     const last = await sync(acc(3), "A");
 
     expect(last.username).toBe("A");
-    expect(await getRow(acc(1))).toEqual({ username: "B", pendingUsername: null });
-    expect(await getRow(acc(2))).toEqual({ username: "C", pendingUsername: null });
-    expect(await getRow(acc(3))).toEqual({ username: "A", pendingUsername: null });
+    expect(await getRow(acc(1))).toEqual({
+      username: "B",
+      pendingUsername: null,
+    });
+    expect(await getRow(acc(2))).toEqual({
+      username: "C",
+      pendingUsername: null,
+    });
+    expect(await getRow(acc(3))).toEqual({
+      username: "A",
+      pendingUsername: null,
+    });
   });
 
   test("chain unwinds when its last wanted name frees up", async () => {
@@ -244,9 +269,18 @@ describe("resolveUsername", () => {
       pendingUsername: null,
       freedName: "N3",
     });
-    expect(await getRow(acc(1))).toEqual({ username: "N2", pendingUsername: null });
-    expect(await getRow(acc(2))).toEqual({ username: "N3", pendingUsername: null });
-    expect(await getRow(acc(3))).toEqual({ username: "N4", pendingUsername: null });
+    expect(await getRow(acc(1))).toEqual({
+      username: "N2",
+      pendingUsername: null,
+    });
+    expect(await getRow(acc(2))).toEqual({
+      username: "N3",
+      pendingUsername: null,
+    });
+    expect(await getRow(acc(3))).toEqual({
+      username: "N4",
+      pendingUsername: null,
+    });
   });
 
   test("chain unwind triggered by the waiting account's own sync", async () => {
@@ -267,8 +301,14 @@ describe("resolveUsername", () => {
       pendingUsername: null,
       freedName: "N1",
     });
-    expect(await getRow(acc(1))).toEqual({ username: "N2", pendingUsername: null });
-    expect(await getRow(acc(2))).toEqual({ username: "N3", pendingUsername: null });
+    expect(await getRow(acc(1))).toEqual({
+      username: "N2",
+      pendingUsername: null,
+    });
+    expect(await getRow(acc(2))).toEqual({
+      username: "N3",
+      pendingUsername: null,
+    });
   });
 
   test("new account with a taken name gets a placeholder + pending", async () => {
@@ -310,8 +350,217 @@ describe("resolveUsername", () => {
     const resolution = await sync(acc(3), "A");
 
     expect(resolution.pendingUsername).toBe("A");
-    expect(await getRow(acc(1))).toEqual({ username: "A", pendingUsername: "B" });
-    expect(await getRow(acc(2))).toEqual({ username: "B", pendingUsername: "A" });
+    expect(await getRow(acc(1))).toEqual({
+      username: "A",
+      pendingUsername: "B",
+    });
+    expect(await getRow(acc(2))).toEqual({
+      username: "B",
+      pendingUsername: "A",
+    });
+  });
+});
+
+describe("resolveUsername — stale holders", () => {
+  test("holder idle under the window still parks the claimant", async () => {
+    await seed(acc(1), "Foo");
+    await seed(acc(2), "Bar");
+    await lastSynced(acc(1), 29);
+
+    const resolution = await sync(acc(2), "Foo");
+
+    expect(resolution.pendingUsername).toBe("Foo");
+    expect(await getRow(acc(1))).toEqual({
+      username: "Foo",
+      pendingUsername: null,
+    });
+  });
+
+  test("stale holder is archived and the claimant granted the name", async () => {
+    await seed(acc(1), "Foo");
+    await seed(acc(2), "Bar");
+    await db
+      .update(accounts)
+      .set({ clanName: "Clan", clanRank: 3 })
+      .where(eq(accounts.id, acc(1)));
+    await lastSynced(acc(1), 31);
+
+    const resolution = await sync(acc(2), "Foo");
+
+    expect(resolution).toEqual({
+      username: "Foo",
+      pendingUsername: null,
+      freedName: "Bar",
+    });
+    expect(await getRow(acc(2))).toEqual({
+      username: "Foo",
+      pendingUsername: null,
+    });
+
+    const archived = await getFullRow(acc(1));
+    expect(archived!.username).toMatch(/^archive_[0-9a-f]{8}$/);
+    expect(archived!.pendingUsername).toBeNull();
+    expect(archived!.clanName).toBeNull();
+    expect(archived!.clanRank).toBeNull();
+  });
+
+  test("new account claiming a stale holder's name gets it outright", async () => {
+    await seed(acc(1), "Foo");
+    await lastSynced(acc(1), 60);
+
+    const resolution = await sync(acc(2), "Foo");
+
+    expect(resolution).toEqual({
+      username: "Foo",
+      pendingUsername: null,
+      freedName: null,
+    });
+    expect(await getRow(acc(2))).toEqual({
+      username: "Foo",
+      pendingUsername: null,
+    });
+    expect((await getRow(acc(1)))!.username).toMatch(/^archive_/);
+  });
+
+  test("a stale row at the end of a chain unblocks the whole chain", async () => {
+    // acc3 (dead) holds N3. acc2 renamed N2 -> N3 and is parked behind acc3.
+    // acc1 renamed N1 -> N2 and syncs: the chain acc1 -> acc2 -> acc3 ends at a
+    // stale row, so acc3 is archived, acc2 gets N3 and acc1 gets N2.
+    await seed(acc(1), "N1");
+    await seed(acc(2), "N2");
+    await seed(acc(3), "N3");
+    await sync(acc(2), "N3"); // parked: acc3 was still active at the time
+    expect(await getRow(acc(2))).toEqual({
+      username: "N2",
+      pendingUsername: "N3",
+    });
+    await lastSynced(acc(3), 45); // ...and has since gone quiet
+
+    const resolution = await sync(acc(1), "N2");
+
+    expect(resolution).toEqual({
+      username: "N2",
+      pendingUsername: null,
+      freedName: "N1",
+    });
+    expect(await getRow(acc(1))).toEqual({
+      username: "N2",
+      pendingUsername: null,
+    });
+    expect(await getRow(acc(2))).toEqual({
+      username: "N3",
+      pendingUsername: null,
+    });
+    expect((await getRow(acc(3)))!.username).toMatch(/^archive_/);
+  });
+
+  test("a stale row that is itself waiting on an active holder is not evicted", async () => {
+    // acc1 (stale) holds A and wants B; acc2 (active) holds B. acc3 wants A.
+    // Only chain-end rows with nothing pending are evicted — acc1 is still
+    // part of a live chain, so acc3 parks.
+    await seed(acc(1), "A");
+    await seed(acc(2), "B");
+    await seed(acc(3), "C");
+    await db
+      .update(accounts)
+      .set({ pendingUsername: "B" })
+      .where(eq(accounts.id, acc(1)));
+    await lastSynced(acc(1), 90);
+
+    const resolution = await sync(acc(3), "A");
+
+    expect(resolution.pendingUsername).toBe("A");
+    expect(await getRow(acc(1))).toEqual({
+      username: "A",
+      pendingUsername: "B",
+    });
+  });
+
+  test("an evicted row that comes back syncs onto its new name normally", async () => {
+    await seed(acc(1), "Foo");
+    await seed(acc(2), "Bar");
+    await lastSynced(acc(1), 40);
+    await sync(acc(2), "Foo");
+
+    // The old holder returns having renamed to Baz in game.
+    const resolution = await sync(acc(1), "Baz");
+
+    expect(resolution.username).toBe("Baz");
+    expect(resolution.pendingUsername).toBeNull();
+    expect(await getRow(acc(1))).toEqual({
+      username: "Baz",
+      pendingUsername: null,
+    });
+    expect(await getRow(acc(2))).toEqual({
+      username: "Foo",
+      pendingUsername: null,
+    });
+  });
+});
+
+describe("sweepStalePendingNames", () => {
+  test("grants claims whose holder went stale after parking", async () => {
+    await seed(acc(1), "Foo");
+    await seed(acc(2), "Bar");
+    await sync(acc(2), "Foo"); // parked: holder active
+    await lastSynced(acc(1), 31);
+    await lastSynced(acc(2), 20); // claimant newer than holder, but also quiet
+
+    const result = await sweepStalePendingNames(db, bucket, kv);
+
+    expect(result.granted).toEqual([
+      { accountId: acc(2), from: "Bar", to: "Foo" },
+    ]);
+    expect(result.skipped).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(await getRow(acc(2))).toEqual({
+      username: "Foo",
+      pendingUsername: null,
+    });
+    expect((await getRow(acc(1)))!.username).toMatch(/^archive_/);
+  });
+
+  test("cascades the claimant's freed name", async () => {
+    await seed(acc(1), "Foo");
+    await seed(acc(2), "Bar");
+    await seed(acc(3), "Baz");
+    await sync(acc(2), "Foo"); // acc2 parked behind acc1
+    await sync(acc(3), "Bar"); // acc3 parked behind acc2
+    await lastSynced(acc(1), 31);
+
+    await sweepStalePendingNames(db, bucket, kv);
+
+    expect(await getRow(acc(2))).toEqual({
+      username: "Foo",
+      pendingUsername: null,
+    });
+    expect(await getRow(acc(3))).toEqual({
+      username: "Bar",
+      pendingUsername: null,
+    });
+  });
+
+  test("leaves claims on active holders and claims older than the holder alone", async () => {
+    await seed(acc(1), "Foo");
+    await seed(acc(2), "Bar");
+    await seed(acc(3), "Qux");
+    await seed(acc(4), "Zed");
+    await sync(acc(2), "Foo"); // holder acc1 active
+    await sync(acc(4), "Qux"); // holder acc3 stale, but claim is even older
+    await lastSynced(acc(3), 40);
+    await lastSynced(acc(4), 50);
+
+    const result = await sweepStalePendingNames(db, bucket, kv);
+
+    expect(result.granted).toEqual([]);
+    expect(await getRow(acc(2))).toEqual({
+      username: "Bar",
+      pendingUsername: "Foo",
+    });
+    expect(await getRow(acc(4))).toEqual({
+      username: "Zed",
+      pendingUsername: "Qux",
+    });
   });
 });
 

--- a/apps/api/src/lib/profiles/resolve-username.ts
+++ b/apps/api/src/lib/profiles/resolve-username.ts
@@ -3,6 +3,7 @@ import { and, eq, ne } from "drizzle-orm";
 import { Database, accounts, lower } from "@runeprofile/db";
 import {
   isPlaceholderUsername,
+  isStaleHolder,
   placeholderUsername,
 } from "@runeprofile/runescape";
 
@@ -23,11 +24,15 @@ import { deleteDiffProfileCache } from "~/lib/profiles/diff-cache";
  *    all names in the cycle rotate at once.
  *  - cascade: after a row moves off a name, any row pending on that name is
  *    granted it (repeated until no more grants).
+ *  - evict: the chain ends at a holder that has not synced for
+ *    STALE_HOLDER_DAYS. The plugin reports the real in-game name, so the
+ *    claimant provably owns it now; the stale holder is archived under a
+ *    placeholder and the chain settles as an unwind.
  *
- * A name is only ever taken from a row by that row's own account reporting a
- * different name — never by another account — so names cannot be stolen.
+ * Otherwise a name is only ever taken from a row by that row's own account
+ * reporting a different name — never by another account — so an active
+ * player's name cannot be stolen.
  */
-
 
 export type UsernameResolution = {
   // What the claimant's row should hold after this sync.
@@ -42,6 +47,7 @@ type AccountNameRow = {
   id: string;
   username: string;
   pendingUsername: string | null;
+  updatedAt: string;
 };
 
 const MAX_CHAIN_LENGTH = 10;
@@ -56,6 +62,7 @@ async function findHolder(
       id: accounts.id,
       username: accounts.username,
       pendingUsername: accounts.pendingUsername,
+      updatedAt: accounts.updatedAt,
     })
     .from(accounts)
     .where(
@@ -78,6 +85,7 @@ async function findClaimant(
       id: accounts.id,
       username: accounts.username,
       pendingUsername: accounts.pendingUsername,
+      updatedAt: accounts.updatedAt,
     })
     .from(accounts)
     .where(eq(lower(accounts.pendingUsername), username.toLowerCase()))
@@ -153,12 +161,15 @@ export async function resolveUsername(
   // holder to see whether the whole chain can be settled right now.
   const chain: AccountNameRow[] = [holder];
   const seenIds = new Set([id, holder.id]);
-  let outcome: "park" | "rotate" | "unwind" = "park";
+  let outcome: "park" | "rotate" | "unwind" | "evict" = "park";
 
   let cursor = holder;
   while (chain.length <= MAX_CHAIN_LENGTH) {
     const wanted = cursor.pendingUsername;
     if (!wanted) {
+      if (isStaleHolder(cursor.updatedAt)) {
+        outcome = "evict";
+      }
       break;
     }
 
@@ -203,10 +214,39 @@ export async function resolveUsername(
 
   // Every row in the chain moves to its pending name, and the claimant takes
   // the reported name. Temp-rename first so the unique index never collides
-  // mid-move, then assign the final names.
+  // mid-move, then assign the final names. An evicted holder simply stays on
+  // its placeholder (its clan fields are dropped like any archived row).
   const claimantHasRow = currentUsername !== null;
+  const evicted = outcome === "evict" ? chain.pop()! : null;
+  const evictedPlaceholder = placeholderUsername();
 
-  await db.transaction(async (tx) => {
+  const moveChain = db.transaction(async (tx) => {
+    if (evicted) {
+      const archived = await tx
+        .update(accounts)
+        .set({
+          username: evictedPlaceholder,
+          clanName: null,
+          clanRank: null,
+          clanIcon: null,
+          clanTitle: null,
+          groupName: null,
+        })
+        .where(
+          and(
+            eq(accounts.id, evicted.id),
+            eq(accounts.username, evicted.username),
+            // Re-check under the transaction: a sync since we looked means the
+            // holder is alive after all.
+            eq(accounts.updatedAt, evicted.updatedAt),
+          ),
+        )
+        .returning({ id: accounts.id });
+      if (archived.length === 0) {
+        throw new StaleHolderRevivedError(evicted.id);
+      }
+    }
+
     for (const row of chain) {
       await tx
         .update(accounts)
@@ -236,8 +276,31 @@ export async function resolveUsername(
     }
   });
 
+  try {
+    await moveChain;
+  } catch (error) {
+    if (!(error instanceof StaleHolderRevivedError)) throw error;
+    console.log({
+      event: "username-parked",
+      accountId: id,
+      wantedUsername: reportedUsername,
+      heldBy: holder.id,
+      reason: "stale holder synced concurrently",
+    });
+    return {
+      username: currentUsername ?? placeholderUsername(),
+      pendingUsername: reportedUsername,
+      freedName: null,
+    };
+  }
+
   console.log({
-    event: outcome === "rotate" ? "username-rotation" : "username-unwind",
+    event:
+      outcome === "rotate"
+        ? "username-rotation"
+        : outcome === "evict"
+          ? "username-evict-stale-holder"
+          : "username-unwind",
     accountId: id,
     username: reportedUsername,
     moved: chain.map((row) => ({
@@ -245,27 +308,50 @@ export async function resolveUsername(
       from: row.username,
       to: row.pendingUsername,
     })),
+    ...(evicted && {
+      evicted: {
+        accountId: evicted.id,
+        from: evicted.username,
+        lastSyncedAt: evicted.updatedAt,
+      },
+    }),
   });
 
   // R2/KV bookkeeping for the moved rows. The claimant's own models and cache
   // are handled by the regular profile update that follows.
-  await Promise.all(
-    chain.map((row) =>
+  await Promise.all([
+    ...chain.map((row) =>
       applyRename(bucket, kv, {
         id: row.id,
         oldUsername: row.username,
         newUsername: row.pendingUsername!,
       }),
     ),
-  );
+    ...(evicted
+      ? [
+          applyRename(bucket, kv, {
+            id: evicted.id,
+            oldUsername: evicted.username,
+            newUsername: evictedPlaceholder,
+          }),
+        ]
+      : []),
+  ]);
 
   // In a rotation the claimant's old name was consumed by the last chain row;
-  // in an unwind it is now free.
+  // in an unwind or eviction it is now free.
   return {
     username: reportedUsername,
     pendingUsername: null,
-    freedName: outcome === "unwind" ? currentUsername : null,
+    freedName: outcome === "rotate" ? null : currentUsername,
   };
+}
+
+/** The holder synced between our read and the archive; treat as "park". */
+class StaleHolderRevivedError extends Error {
+  constructor(public readonly holderId: string) {
+    super("Stale holder synced concurrently");
+  }
 }
 
 /**

--- a/apps/api/src/lib/profiles/sweep-stale-names.ts
+++ b/apps/api/src/lib/profiles/sweep-stale-names.ts
@@ -1,0 +1,127 @@
+import { aliasedTable, and, eq, gt, isNotNull, ne, sql } from "drizzle-orm";
+
+import { Database, accounts, lower } from "@runeprofile/db";
+import { STALE_HOLDER_DAYS } from "@runeprofile/runescape";
+
+import { renamePlayerModels } from "~/lib/models/manage-models";
+import { deleteDiffProfileCache } from "~/lib/profiles/diff-cache";
+import {
+  cascadeFreedName,
+  resolveUsername,
+} from "~/lib/profiles/resolve-username";
+
+// Each grant is a transaction plus R2 moves and KV deletes; keep one run well
+// inside Worker limits. Anything left over is picked up by the next run.
+const SWEEP_BATCH_SIZE = 50;
+
+export type SweepResult = {
+  granted: { accountId: string; from: string; to: string }[];
+  skipped: number;
+  failed: number;
+};
+
+/**
+ * Settles pending usernames whose holder has gone stale since the claim was
+ * parked. The sync path already evicts a stale holder at claim time; this
+ * catches claims that were parked while the holder was still within the
+ * window and whose claimant has not synced since.
+ *
+ * Each claim is replayed through `resolveUsername` exactly as if the claimant
+ * had synced its pending name, so the sweep cannot do anything a sync could
+ * not. A claim is only replayed when it is newer than the holder's last sync —
+ * the claim must be the more recent sighting of the name.
+ */
+export async function sweepStalePendingNames(
+  db: Database,
+  bucket: R2Bucket,
+  kv: KVNamespace,
+): Promise<SweepResult> {
+  const holder = aliasedTable(accounts, "holder");
+  const claims = await db
+    .select({
+      id: accounts.id,
+      username: accounts.username,
+      pendingUsername: accounts.pendingUsername,
+    })
+    .from(accounts)
+    .innerJoin(
+      holder,
+      and(
+        eq(lower(holder.username), lower(accounts.pendingUsername)),
+        ne(holder.id, accounts.id),
+      ),
+    )
+    .where(
+      and(
+        isNotNull(accounts.pendingUsername),
+        sql`${holder.updatedAt} < now() - ${sql.raw(`interval '${STALE_HOLDER_DAYS} days'`)}`,
+        gt(accounts.updatedAt, holder.updatedAt),
+      ),
+    )
+    .orderBy(sql`${holder.updatedAt} ASC`)
+    .limit(SWEEP_BATCH_SIZE);
+
+  const result: SweepResult = { granted: [], skipped: 0, failed: 0 };
+
+  for (const claim of claims) {
+    const wanted = claim.pendingUsername!;
+    try {
+      const resolution = await resolveUsername(db, bucket, kv, {
+        id: claim.id,
+        reportedUsername: wanted,
+        currentUsername: claim.username,
+      });
+
+      if (resolution.pendingUsername !== null) {
+        // Holder came back to life (or a chain we cannot settle); leave it.
+        result.skipped++;
+        continue;
+      }
+
+      // resolveUsername leaves the claimant's own row to the caller (it may
+      // already carry the new name from an in-transaction move); apply the
+      // resolution the way the profile update does, minus activity bookkeeping.
+      await db
+        .update(accounts)
+        .set({ username: resolution.username, pendingUsername: null })
+        .where(eq(accounts.id, claim.id));
+
+      await Promise.all([
+        deleteDiffProfileCache(kv, claim.id).catch((error) => {
+          console.error(`Failed to delete diff cache for ${claim.id}:`, error);
+        }),
+        renamePlayerModels(bucket, claim.username, resolution.username).catch(
+          (error) => {
+            console.error(
+              `Failed to rename player models for ${claim.id}:`,
+              error,
+            );
+          },
+        ),
+      ]);
+
+      if (resolution.freedName) {
+        await cascadeFreedName(db, bucket, kv, resolution.freedName);
+      }
+
+      result.granted.push({
+        accountId: claim.id,
+        from: claim.username,
+        to: resolution.username,
+      });
+    } catch (error) {
+      result.failed++;
+      console.error(`Stale-name sweep failed for ${claim.id}:`, error);
+    }
+  }
+
+  console.log({
+    event: "stale-pending-names-swept",
+    candidates: claims.length,
+    granted: result.granted.length,
+    skipped: result.skipped,
+    failed: result.failed,
+  });
+
+  return result;
+}

--- a/packages/runescape/src/usernames.ts
+++ b/packages/runescape/src/usernames.ts
@@ -12,3 +12,17 @@ export function placeholderUsername(): string {
 export function isPlaceholderUsername(username: string): boolean {
   return username.startsWith("archive_");
 }
+
+// A row that has not synced for this long is treated as no longer owning its
+// name: the plugin reports the actual in-game name, so a claimant reporting a
+// held name proves the holder has either renamed or gone. This window only
+// has to cover the lag between a holder renaming and their next login.
+export const STALE_HOLDER_DAYS = 30;
+
+export function isStaleHolder(
+  lastSyncedAt: string | Date | null,
+  now: number = Date.now(),
+): boolean {
+  if (!lastSyncedAt) return false;
+  return now - new Date(lastSyncedAt).getTime() >= STALE_HOLDER_DAYS * 86400000;
+}


### PR DESCRIPTION
## Why

A name was only ever freed by its holder's **own** sync. A holder that stopped syncing (quit, uninstalled the plugin, name released by Jagex) therefore blocked its claimant forever, and one dead row could hold up a whole chain of renames. That is the backlog visible on the admin Pending Names page.

The plugin reports the real in-game name, so a claimant reporting a held name proves the holder has renamed or gone; parking only needs to cover the lag until a renamed holder's next login.

## What

- **`resolveUsername`**: a chain that ends at a holder with nothing pending and no sync for `STALE_HOLDER_DAYS` (30) is now settled instead of parked: the holder is archived under a placeholder (clan fields cleared, same as the admin Archive/Resolve), the rest of the chain moves like an unwind, and the claimant's old name cascades to whoever is waiting on it. The archive re-checks the holder's `updatedAt` inside the transaction and falls back to parking if the holder synced in between. Rows that are stale but themselves waiting on an active holder are *not* evicted.
- **`sweepStalePendingNames`** (`apps/api/src/lib/profiles/sweep-stale-names.ts`): replays already-parked claims through `resolveUsername` exactly as if the claimant synced its pending name, only when the claim is newer than the holder's last sync. Batches of 50. This covers claims parked while the holder was still within the window whose claimant has since gone quiet.
- `STALE_HOLDER_DAYS` / `isStaleHolder` move to `@runeprofile/runescape`; the admin re-exports them so both sides share one definition.

## Not in this PR

Wiring the sweep to a cron trigger (`scheduled` handler in `apps/api/src/index.ts` + `triggers.crons` in `wrangler.jsonc`). Two-line follow-up.

## Verification

- 137/137 API tests pass (`vitest run`), including 9 new PGlite tests: under/over the window, new-account claim, chain unblocking, stale-but-waiting row not evicted, evicted row returning, sweep grant, sweep cascade, sweep leaving active/older claims alone.
- `tsc --noEmit` clean in `apps/api`, `apps/admin`, `apps/web`; admin lint has only pre-existing warnings.
- Not exercised against production data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)