### PR TITLE
feat(api): run the stale pending-name sweep daily via a cron trigger

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,7 @@
 import { cors } from "hono/cors";
 
+import { drizzle } from "@runeprofile/db";
+
 import { clansRouter } from "~/internal/routes/clans";
 import { discordRouter } from "~/internal/routes/discord";
 import { groupsRouter } from "~/internal/routes/groups";
@@ -9,9 +11,10 @@ import { metricsRouter } from "~/internal/routes/metrics";
 import { profilesRouter } from "~/internal/routes/profiles";
 import { simulateRouter } from "~/internal/routes/simulate";
 import { errorHandler, logger, newRouter } from "~/lib/helpers";
+import { sweepStalePendingNames } from "~/lib/profiles/sweep-stale-names";
 import { publicApiV1 } from "~/public/v1/index";
 
-export default newRouter()
+export const app = newRouter()
   .onError(errorHandler)
   .use(
     "*",
@@ -37,3 +40,12 @@ export default newRouter()
   .route("/metrics", metricsRouter)
   .route("/discord", discordRouter)
   .route("/simulate", simulateRouter);
+
+export default {
+  fetch: app.fetch,
+  scheduled(_event, env, ctx) {
+    ctx.waitUntil(
+      sweepStalePendingNames(drizzle(env.HYPERDRIVE), env.BUCKET, env.KV),
+    );
+  },
+} satisfies ExportedHandler<Env>;

--- a/apps/api/src/lib/api-client.ts
+++ b/apps/api/src/lib/api-client.ts
@@ -1,6 +1,6 @@
 import { hc } from "hono/client";
 
-import app from "..";
+import { app } from "..";
 
 // assign the client to a variable to calculate the type when compiling
 const client = hc<typeof app>("");

--- a/apps/api/wrangler.jsonc
+++ b/apps/api/wrangler.jsonc
@@ -9,6 +9,11 @@
   "placement": {
     "region": "aws:us-east-1"
   },
+  // Daily sweep of pending usernames whose holder has gone stale
+  // (src/lib/profiles/sweep-stale-names.ts via the scheduled handler).
+  "triggers": {
+    "crons": ["15 4 * * *"]
+  },
   "routes": [
     {
       "pattern": "api.runeprofile.com",


### PR DESCRIPTION
Follow-up to #45, which added `sweepStalePendingNames` without scheduling it.

- `wrangler.jsonc`: `triggers.crons = ["15 4 * * *"]` (daily, 04:15 UTC).
- `src/index.ts`: default export is now `{ fetch: app.fetch, scheduled }`; the scheduled handler runs the sweep under `ctx.waitUntil`. The Hono app is exported as `app`.
- `src/lib/api-client.ts`: derives the client type from `app` instead of the default export (which is no longer a Hono instance).

Verification: `tsc --noEmit` clean in `apps/api` and `apps/web`, 137/137 API tests, `wrangler deploy --dry-run` succeeds. Local test of the schedule: `wrangler dev --test-scheduled` then `curl localhost:8787/__scheduled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)