### PR TITLE
fix(api): card title overflow, and pearlescent text losing its spaces

### DIFF
--- a/apps/api/src/internal/discord/cards/activity-cards.ts
+++ b/apps/api/src/internal/discord/cards/activity-cards.ts
@@ -16,6 +16,10 @@ import {
 
 import CardAssets from "~/internal/discord/cards/card-assets.json";
 import {
+  initFontMetrics,
+  measureText,
+} from "~/internal/discord/cards/font-metrics";
+import {
   getItemIconUrl,
   getItemName,
   numberWithAbbreviation,
@@ -89,8 +93,108 @@ const CARD_HEIGHT = Math.round(
  */
 const S = CARD_WIDTH / CARD_AUTHORED_WIDTH;
 
-/** Vertical gap between the header, the panel and the footer. */
-const ROW_GAP = 10;
+/**
+ * Where the three rows sit, in authored units.
+ *
+ * The header and footer are placed against the card rather than sharing a
+ * centred column with the panel, so a tall panel can never push the
+ * player's name off the top or the profile link off the bottom - it is
+ * bounded by the band between them instead.
+ *
+ * The band is deep enough for a two-line title over a one-line subtitle,
+ * which is what the longest CA task and quest names need.
+ */
+const HEADER_TOP = 14;
+const FOOTER_BOTTOM = 14;
+const BAND_TOP = 53;
+const BAND_HEIGHT = 118;
+
+/**
+ * Width the panel has for its contents: the content column, less the
+ * card's own borders, the panel's border and its padding.
+ *
+ * satori positions an absolute child against the border box but sizes it
+ * inside the padding box, so the card's 2-unit borders come off the column
+ * width as well - which is why this is 394 and not 398.
+ */
+const PANEL_INNER = 440 - 2 * 2 - 2 * 2 - 2 * 19;
+
+/** A unit of slack, so a string measured to the edge does not wrap. */
+const FIT_SLACK = 2;
+
+/** Sizes the title may be set at, largest first. */
+const TITLE_SIZES = [32, 29, 26, 23, 21];
+const MIN_TITLE_SIZE = 21;
+
+const SUBTITLE_SIZE = 23;
+const TITLE_LINE_HEIGHT = 1.05;
+const SUBTITLE_LINE_HEIGHT = 1.1;
+
+/** Panel padding and border, vertically. */
+const PANEL_CHROME = 13 * 2 + 2 * 2;
+
+/**
+ * Width left for the title and subtitle once the icon tile, the row gaps
+ * and anything on the right are paid for.
+ */
+function textColumnWidth(rightWidth: number): number {
+  const gaps = rightWidth > 0 ? 15 * 2 : 15;
+  return PANEL_INNER - 64 - gaps - rightWidth - FIT_SLACK;
+}
+
+/** Largest title size whose two lines still fit the band with a subtitle. */
+const TWO_LINE_MAX_SIZE = Math.floor(
+  (BAND_HEIGHT - PANEL_CHROME - SUBTITLE_SIZE * SUBTITLE_LINE_HEIGHT - 3) /
+    (2 * TITLE_LINE_HEIGHT),
+);
+
+/** Cuts a string down until it fits, marking the cut with an ellipsis. */
+function ellipsize(
+  text: string,
+  weight: "regular" | "bold",
+  size: number,
+  available: number,
+): string {
+  if (measureText(text, weight, size) <= available) return text;
+  let out = text;
+  while (out.length > 1 && measureText(`${out}...`, weight, size) > available) {
+    out = out.slice(0, -1);
+  }
+  return `${out.trimEnd()}...`;
+}
+
+/**
+ * Fits the title to the column: the largest size that holds it on one
+ * line, or failing that two lines at a size the band can take, and only
+ * as a last resort an ellipsis.
+ *
+ * One line is preferred while the size is still respectable rather than
+ * jumping straight to two at full size, because the card is read at a
+ * glance in a channel and a single line scans faster. Wrapping is only
+ * offered when nothing sits to the right of the text: sharing the row with
+ * a value leaves a column too narrow for two lines to read as one title.
+ */
+function fitTitle(title: string, available: number, mayWrap: boolean) {
+  for (const size of TITLE_SIZES) {
+    if (measureText(title, "bold", size) <= available) return { title, size };
+  }
+
+  if (mayWrap) {
+    for (const size of TITLE_SIZES) {
+      if (size > TWO_LINE_MAX_SIZE) continue;
+      // Word wrapping cannot fill both lines to the edge, so only claim
+      // most of the second line.
+      if (measureText(title, "bold", size) <= available * 1.9) {
+        return { title, size };
+      }
+    }
+  }
+
+  return {
+    title: ellipsize(title, "bold", MIN_TITLE_SIZE, available),
+    size: MIN_TITLE_SIZE,
+  };
+}
 
 const png = (base64: string) => `data:image/png;base64,${base64}`;
 
@@ -178,6 +282,12 @@ let fonts:
   | null = null;
 
 function loadFonts() {
+  if (!fonts) {
+    initFontMetrics({
+      regular: base64ToBytes(CardAssets.fontRegular),
+      bold: base64ToBytes(CardAssets.fontBold),
+    });
+  }
   fonts ??= [
     {
       name: "RuneScape",
@@ -271,7 +381,12 @@ type CardContent = {
   panelIcon: string;
   panelTitle: string;
   panelSubtitle: string;
-  /** Big number on the panel's right side (level, XP, tier). */
+  /**
+   * Big number on the panel's right side: a level, an XP total, a total
+   * level. Numbers only - a word here (a diary or CA tier) takes so much
+   * of the row that the title has to wrap, and it only repeats what the
+   * title or the subtitle already says.
+   */
   badge?: string;
 };
 
@@ -461,9 +576,12 @@ function buildCardContent(activity: ActivityEvent): CardContent {
         nameColor: "#f2ce63",
         verb: "completed a diary tier",
         panelIcon: png(CardAssets.diaryIcon),
-        panelTitle: `${area} Diary`,
-        panelSubtitle: `${tierName} tier complete`,
-        badge: tierName,
+        // The tier rides in the title and "Diary" comes off it, because
+        // the subtitle says that already. As a badge the tier word was
+        // wide enough ("Medium" alone takes 156 of the 304 units the row
+        // had) to squeeze the title into wrapping.
+        panelTitle: `${area} ${tierName}`,
+        panelSubtitle: "Achievement Diary",
       };
     }
     case "combat_achievement_tier_completed":
@@ -567,10 +685,23 @@ export function buildCardHtml(params: {
       accountType.key as keyof typeof CardAssets.accountTypeIconsShadowed
     ];
 
-  const title = escapeHtml(content.panelTitle);
-  // Long titles (quests, CA tasks) drop to a smaller size so they stay
-  // on one line-ish; satori wraps if they still overflow.
-  const titleSize = content.panelTitle.length > 18 ? 25 * S : 32 * S;
+  // The right-hand value is resolved first, because what it leaves is the
+  // width everything else has to be fitted into.
+  const badgeWidth = content.badge ? measureText(content.badge, "bold", 52) : 0;
+  const available = textColumnWidth(badgeWidth);
+
+  // A title may take a second line only when nothing shares its row: CA
+  // task and quest names run past 40 characters, and reading them in full
+  // beats truncating them.
+  const fitted = fitTitle(content.panelTitle, available, !content.badge);
+  const title = escapeHtml(fitted.title);
+  const titleSize = fitted.size * S;
+  const subtitle = ellipsize(
+    content.panelSubtitle,
+    content.subtitlePearl ? "bold" : "regular",
+    SUBTITLE_SIZE,
+    available,
+  );
 
   const shadowSm = `text-shadow: ${2 * S}px ${2 * S}px 0 rgba(0,0,0,0.9);`;
   // The name gets the same treatment as the account icon beside it: a
@@ -639,7 +770,7 @@ export function buildCardHtml(params: {
   // hues, since a text gradient isn't in satori's vocabulary.
   const PEARL_HUES = ["#7ee7ff", "#cf8cff", "#ff8cd2", "#8cffd2"];
   const subtitleHtml = content.subtitlePearl
-    ? (content.panelSubtitle.match(/\S\s*/g) ?? [])
+    ? (subtitle.match(/\S\s*/g) ?? [])
         .map(
           // Spaces ride inside the preceding character's span - the
           // renderer collapses whitespace-only nodes entirely.
@@ -647,7 +778,7 @@ export function buildCardHtml(params: {
             `<span style="font-size: ${23 * S}px; font-weight: 700; color: ${PEARL_HUES[i % PEARL_HUES.length]}; line-height: 1.1; ${shadowSm}">${escapeHtml(chunk)}</span>`,
         )
         .join("")
-    : `<span style="font-size: ${23 * S}px; color: ${content.subtitleColor ?? "#9f9f9f"}; line-height: 1.1; ${shadowSm}">${escapeHtml(content.panelSubtitle)}</span>`;
+    : `<span style="font-size: ${SUBTITLE_SIZE * S}px; color: ${content.subtitleColor ?? "#9f9f9f"}; line-height: ${SUBTITLE_LINE_HEIGHT}; ${shadowSm}">${escapeHtml(subtitle)}</span>`;
 
   return `
     <div style="display: flex; position: relative; width: ${CARD_WIDTH}px; height: ${CARD_HEIGHT}px; overflow: hidden; background-color: #0d0d0c; font-family: 'RuneScape'; border-radius: ${10 * S}px; border: ${2 * S}px solid #3b3831;">
@@ -661,25 +792,31 @@ export function buildCardHtml(params: {
       <img src="${avatarDataUri}" width="${CARD_WIDTH}" height="${CARD_HEIGHT}" style="position: absolute; left: 0; top: 0;" />
       <div style="display: flex; position: absolute; left: 0; top: 0; bottom: 0; width: ${3 * S}px; border-radius: ${10 * S}px 0 0 ${10 * S}px; background-image: ${edge};"></div>
 
-      <div style="display: flex; flex-direction: column; justify-content: center; gap: ${ROW_GAP * S}px; position: absolute; left: ${256 * S}px; top: 0; bottom: 0; right: ${24 * S}px;">
-        ${header}
-
-        <div style="display: flex; align-items: center; gap: ${15 * S}px; background-color: ${PANEL_FILL}; border-style: solid; border-width: ${2 * S}px; border-color: ${PANEL_BORDER}; border-radius: ${6 * S}px; padding: ${13 * S}px ${19 * S}px;">
-          <div style="display: flex; align-items: center; justify-content: center; width: ${64 * S}px; height: ${64 * S}px; background-color: rgba(255,255,255,0.08); border-radius: ${6 * S}px; border: ${1 * S}px solid rgba(255,255,255,0.06);">
-            <img src="${content.panelIcon}" width="${48 * S}" height="${48 * S}" />
-          </div>
-          <div style="display: flex; flex-direction: column; gap: ${3 * S}px; flex: 1;">
-            <span style="font-size: ${titleSize}px; font-weight: 700; color: #e2e2e2; line-height: 1.05; ${shadowSm}">${title}</span>
-            <div style="display: flex;">${subtitleHtml}</div>
-          </div>
-          ${
-            content.badge
-              ? `<span style="font-size: ${52 * S}px; font-weight: 700; color: ${rgba(content.accent, 1)}; line-height: 1; ${shadowSm}">${escapeHtml(content.badge)}</span>`
-              : ""
-          }
+      <div style="display: flex; position: absolute; left: ${256 * S}px; top: 0; bottom: 0; right: ${24 * S}px;">
+        <div style="display: flex; flex-direction: column; position: absolute; left: 0; right: 0; top: ${HEADER_TOP * S}px;">
+          ${header}
         </div>
 
-        ${footer}
+        <div style="display: flex; flex-direction: column; justify-content: center; overflow: hidden; position: absolute; left: 0; right: 0; top: ${BAND_TOP * S}px; height: ${BAND_HEIGHT * S}px;">
+          <div style="display: flex; align-items: center; gap: ${15 * S}px; background-color: ${PANEL_FILL}; border-style: solid; border-width: ${2 * S}px; border-color: ${PANEL_BORDER}; border-radius: ${6 * S}px; padding: ${13 * S}px ${19 * S}px;">
+            <div style="display: flex; align-items: center; justify-content: center; width: ${64 * S}px; height: ${64 * S}px; background-color: rgba(255,255,255,0.08); border-radius: ${6 * S}px; border: ${1 * S}px solid rgba(255,255,255,0.06);">
+              <img src="${content.panelIcon}" width="${48 * S}" height="${48 * S}" />
+            </div>
+            <div style="display: flex; flex-direction: column; gap: ${3 * S}px; flex: 1;">
+              <span style="font-size: ${titleSize}px; font-weight: 700; color: #e2e2e2; line-height: ${TITLE_LINE_HEIGHT}; ${shadowSm}">${title}</span>
+              <div style="display: flex;">${subtitleHtml}</div>
+            </div>
+            ${
+              content.badge
+                ? `<span style="font-size: ${52 * S}px; font-weight: 700; color: ${rgba(content.accent, 1)}; line-height: 1; ${shadowSm}">${escapeHtml(content.badge)}</span>`
+                : ""
+            }
+          </div>
+        </div>
+
+        <div style="display: flex; flex-direction: column; position: absolute; left: 0; right: 0; bottom: ${FOOTER_BOTTOM * S}px;">
+          ${footer}
+        </div>
       </div>
     </div>`;
 }

--- a/apps/api/src/internal/discord/cards/activity-cards.ts
+++ b/apps/api/src/internal/discord/cards/activity-cards.ts
@@ -733,8 +733,10 @@ export function buildCardHtml(params: {
   const nameHtml = content.namePearl
     ? `<div style="display: flex;">${(name.match(/\S\s*/g) ?? [])
         .map(
+          // As with the subtitle: preserve the spaces, or a two-word name
+          // renders as one.
           (chunk, i) =>
-            `<span style="font-size: ${35 * S}px; font-weight: 700; color: ${PEARL_NAME_HUES[i % PEARL_NAME_HUES.length]}; line-height: 1; ${shadowName}">${chunk}</span>`,
+            `<span style="font-size: ${35 * S}px; font-weight: 700; color: ${PEARL_NAME_HUES[i % PEARL_NAME_HUES.length]}; line-height: 1; white-space: pre; ${shadowName}">${chunk}</span>`,
         )
         .join("")}</div>`
     : `<span style="font-size: ${35 * S}px; font-weight: 700; color: ${nameColor}; line-height: 1; ${shadowName}">${name}</span>`;
@@ -772,10 +774,12 @@ export function buildCardHtml(params: {
   const subtitleHtml = content.subtitlePearl
     ? (subtitle.match(/\S\s*/g) ?? [])
         .map(
-          // Spaces ride inside the preceding character's span - the
-          // renderer collapses whitespace-only nodes entirely.
+          // Spaces ride inside the preceding character's span, since a
+          // whitespace-only node is collapsed away entirely - and the span
+          // has to preserve them, or the trailing space is trimmed and the
+          // words run together ("200,000,000XP").
           (chunk, i) =>
-            `<span style="font-size: ${23 * S}px; font-weight: 700; color: ${PEARL_HUES[i % PEARL_HUES.length]}; line-height: 1.1; ${shadowSm}">${escapeHtml(chunk)}</span>`,
+            `<span style="font-size: ${SUBTITLE_SIZE * S}px; font-weight: 700; color: ${PEARL_HUES[i % PEARL_HUES.length]}; line-height: ${SUBTITLE_LINE_HEIGHT}; white-space: pre; ${shadowSm}">${escapeHtml(chunk)}</span>`,
         )
         .join("")
     : `<span style="font-size: ${SUBTITLE_SIZE * S}px; color: ${content.subtitleColor ?? "#9f9f9f"}; line-height: ${SUBTITLE_LINE_HEIGHT}; ${shadowSm}">${escapeHtml(subtitle)}</span>`;

--- a/apps/api/src/internal/discord/cards/font-metrics.ts
+++ b/apps/api/src/internal/discord/cards/font-metrics.ts
@@ -1,0 +1,143 @@
+/**
+ * Text measurement for the card layout.
+ *
+ * The card has a fixed height and a narrow content column, so the layout
+ * has to know how wide a string will come out *before* handing it to
+ * satori: too wide and it wraps, and a wrapped line is what pushed the
+ * player's name off the top of the card.
+ *
+ * The widths are read out of the very font the card renders with, rather
+ * than kept alongside it as a table, so the two cannot drift apart when
+ * the font is replaced.
+ */
+
+/** Advance widths per character, as a fraction of the font size. */
+type FontWidths = {
+  widths: Map<number, number>;
+  /** Advance of the glyph a missing character falls back to. */
+  missing: number;
+};
+
+/**
+ * Reads the advance widths out of a TrueType font: the `hmtx` table holds
+ * them per glyph, `cmap` maps characters to glyphs, and `head` gives the
+ * em size everything is expressed in.
+ *
+ * Only cmap format 4 is handled, which is the format a modern font uses
+ * for the Basic Multilingual Plane. A font without one measures as all
+ * missing glyphs, which the fitting treats as a very wide string - it
+ * shrinks the text rather than overflowing the card.
+ */
+function readFontWidths(font: Uint8Array): FontWidths {
+  const view = new DataView(font.buffer, font.byteOffset, font.byteLength);
+  const u16 = (at: number) => view.getUint16(at);
+  const i16 = (at: number) => view.getInt16(at);
+  const u32 = (at: number) => view.getUint32(at);
+
+  const tables = new Map<string, number>();
+  const numTables = u16(4);
+  for (let i = 0; i < numTables; i++) {
+    const record = 12 + i * 16;
+    const tag = String.fromCharCode(
+      view.getUint8(record),
+      view.getUint8(record + 1),
+      view.getUint8(record + 2),
+      view.getUint8(record + 3),
+    );
+    tables.set(tag, u32(record + 8));
+  }
+
+  const head = tables.get("head");
+  const hhea = tables.get("hhea");
+  const hmtx = tables.get("hmtx");
+  const cmap = tables.get("cmap");
+  if (!head || !hhea || !hmtx || !cmap) {
+    return { widths: new Map(), missing: 0.5 };
+  }
+
+  const unitsPerEm = u16(head + 18) || 1000;
+  const hMetrics = u16(hhea + 34);
+  // Past the last full metric every glyph repeats the last advance.
+  const advance = (glyph: number) =>
+    u16(hmtx + Math.min(glyph, hMetrics - 1) * 4) / unitsPerEm;
+
+  // Prefer a Windows Unicode subtable, then any Unicode one.
+  let best: { at: number; score: number } | null = null;
+  const subtables = u16(cmap + 2);
+  for (let i = 0; i < subtables; i++) {
+    const record = cmap + 4 + i * 8;
+    const platform = u16(record);
+    const encoding = u16(record + 2);
+    const score = platform === 3 && encoding === 1 ? 3 : platform === 0 ? 2 : 1;
+    if (!best || score > best.score) {
+      best = { at: cmap + u32(record + 4), score };
+    }
+  }
+
+  const widths = new Map<number, number>();
+  if (best && u16(best.at) === 4) {
+    const at = best.at;
+    const segments = u16(at + 6) / 2;
+    const endsAt = at + 14;
+    const startsAt = endsAt + segments * 2 + 2;
+    const deltasAt = startsAt + segments * 2;
+    const rangesAt = deltasAt + segments * 2;
+
+    for (let s = 0; s < segments; s++) {
+      const end = u16(endsAt + s * 2);
+      const start = u16(startsAt + s * 2);
+      const delta = i16(deltasAt + s * 2);
+      const rangeOffset = u16(rangesAt + s * 2);
+      if (start === 0xffff) continue;
+
+      for (let code = start; code <= end && code !== 0xffff; code++) {
+        let glyph: number;
+        if (rangeOffset === 0) {
+          glyph = (code + delta) & 0xffff;
+        } else {
+          const at = rangesAt + s * 2 + rangeOffset + (code - start) * 2;
+          if (at + 1 >= font.byteLength) continue;
+          glyph = u16(at);
+          if (glyph !== 0) glyph = (glyph + delta) & 0xffff;
+        }
+        if (glyph !== 0) widths.set(code, advance(glyph));
+      }
+    }
+  }
+
+  return { widths, missing: advance(0) };
+}
+
+let cache: { regular: FontWidths; bold: FontWidths } | null = null;
+
+/** Both faces, parsed once per isolate. */
+export function initFontMetrics(fonts: {
+  regular: Uint8Array;
+  bold: Uint8Array;
+}) {
+  cache ??= {
+    regular: readFontWidths(fonts.regular),
+    bold: readFontWidths(fonts.bold),
+  };
+  return cache;
+}
+
+/**
+ * Width of a string at a given font size, in the same units the size is
+ * given in. Bold and regular have their own metrics: the bold face is
+ * wider, and measuring a bold title against regular widths would let it
+ * wrap.
+ */
+export function measureText(
+  text: string,
+  weight: "regular" | "bold",
+  size: number,
+): number {
+  if (!cache) return text.length * 0.5 * size;
+  const font = cache[weight];
+  let em = 0;
+  for (const ch of text) {
+    em += font.widths.get(ch.codePointAt(0) ?? 0) ?? font.missing;
+  }
+  return em * size;
+}


### PR DESCRIPTION
Two card rendering fixes.

## 1. A long title pushed the name and link off the card

A diary card — `Falador Diary` with a `Medium` badge — pushed the player's name off the top of the card and the profile link off the bottom.

The header, panel and footer shared one flex column, centred in a fixed-height card. Nothing bounded the panel, so when it outgrew its share the overflow split above *and* below, and the card's `overflow: hidden` sliced both rows.

It starts as a **width** problem. The badge takes its width from the same row as the title:

| | units |
|---|---|
| Content column, inside the card border | 436 |
| Panel padding and border | −42 |
| Icon tile and the two gaps | −96 |
| Badge `"Medium"` at 52u | −156 |
| **Left for the title and subtitle** | **142** |
| Title `"Falador Diary"` needs | 174 |
| Subtitle `"Medium tier complete"` needs | 171 |

Both wrapped, the panel grew to 150 units against a 134-unit budget, and the rows were shoved out. `"Grandmaster"` as a badge would have left 22 units.

**The fix:**

- **The header and footer are placed against the card** rather than sharing a centred column, so the panel cannot move them at all. It gets the band between them and clips inside it in the worst case — the name and link can never leave the frame again, whatever ships later.
- **Tier words come off the right-hand side.** A diary names its tier in the title instead — `Falador Medium` over `Achievement Diary` — which is narrower than repeating "Diary" in both. Numbers stay: a level, an XP total and a total level are narrow and are the point of the event.
- **Titles are measured** against the width that leaves them and set at the largest size that holds one line. Where nothing shares the row — CA tasks and quests, whose names reach 46 characters — a title that fits no size takes two lines rather than being truncated.

`font-metrics.ts` reads advance widths out of the card font itself (parsed once per isolate) rather than shipping a table beside it, so the layout math cannot drift from the font that renders.

## 2. Pearlescent text lost every space

The pearlescent treatment colours each character separately, so it splits the string into one span per character with any following space riding inside it — a whitespace-only span is collapsed away entirely. But a *trailing* space in a span is trimmed too, so every space vanished: `200,000,000 XP` rendered as `200,000,000XP`, and a 100m+ drop as `1,150,000,000gp`. The player's name is split the same way, so a pearlescent event for a two-word RSN rendered `LynxTitan`.

`white-space: pre` on those spans keeps them. The font has no U+00A0, so substituting a non-breaking space would have drawn a missing glyph.

## Verification

- All **32 event examples** — every event type, each with its short, typical and worst case, names and ids taken from the game data — render with nothing clipped, three taking a second line, none ellipsized.
- Renders compared **byte-for-byte** against the approved set at each step. After the whitespace fix, exactly the two pearlescent-subtitle cards differ and the other eight are unchanged, which is the intended blast radius.
- Typecheck clean; api test suite 137 passing.
- Both batches sent through the dev bot to Discord and checked in the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
